### PR TITLE
adds Module for monitoring bytes_sent from GCS buckets

### DIFF
--- a/gcs-egress-monitoring/main.tf
+++ b/gcs-egress-monitoring/main.tf
@@ -1,0 +1,19 @@
+resource "google_monitoring_alert_policy" "gcs_bucket_egress_alarm" {
+  display_name = "bucket egress"
+  combiner     = "OR"
+  conditions {
+    display_name = "GCS storage egress has exceeded the allowed threshold"
+    condition_threshold {
+      filter          = "metric.type=\"storage.googleapis.com/network/sent_bytes_count\" resource.type=\"gcs_bucket\" resource.label.\"bucket_name\"=\"${var.gcs_bucket_name}\""
+      duration        = var.sent_bytes_alerting_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.sent_bytes_alerting_threshold
+      aggregations {
+        alignment_period   = var.sent_bytes_alerting_alignment_period
+        per_series_aligner = "ALIGN_MEAN"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+}

--- a/gcs-egress-monitoring/variables.tf
+++ b/gcs-egress-monitoring/variables.tf
@@ -1,0 +1,30 @@
+variable "gcs_bucket_name" {
+  type        = string
+  description = "The name of the GCS bucket you'd like to monitor"
+
+  validation {
+    condition     = length(var.gcs_bucket_name) >= 3
+    error_message = "The gcs_bucket_name must be 3 or more characters."
+  }
+}
+
+variable "sent_bytes_alerting_threshold" {
+  type        = number
+  description = "The number of bytes sent, to be used as a threshold for alerting"
+}
+
+variable "sent_bytes_alerting_duration" {
+  type        = string
+  description = "The number of seconds to evaluate an alert threshold on. As a string, 60 seconds would be represented as '60s'"
+}
+
+variable "sent_bytes_alerting_alignment_period" {
+  type = string
+  description = "The number of seconds to use for the alignment period when evaluating an alert condition. As a string, 60 seconds would be represented as '60s'"
+
+}
+
+variable "notification_channels" {
+  type        = list(string)
+  description = "A list of notification channel IDs. These should be defined in your project's configuration, and supplied here as an input to the module"
+}

--- a/gcs-egress-monitoring/variables.tf
+++ b/gcs-egress-monitoring/variables.tf
@@ -17,7 +17,7 @@ variable "sent_bytes_alerting_duration" {
   type        = string
   description = "The number of seconds to evaluate an alert threshold on. As a string, 60 seconds would be represented as '60s'"
   validation {
-    condition     = substr(var.sent_bytes_alerting_duration, -2, -1) == "s"
+    condition     = substr(var.sent_bytes_alerting_duration, -1, -1) == "s"
     error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'."
   }
 }
@@ -26,7 +26,7 @@ variable "sent_bytes_alerting_alignment_period" {
   type        = string
   description = "The number of seconds to use for the alignment period when evaluating an alert condition. As a string, 60 seconds would be represented as '60s'"
   validation {
-    condition     = substr(var.sent_bytes_alerting_alignment_period, -2, -1) == "s"
+    condition     = substr(var.sent_bytes_alerting_alignment_period, -1, -1) == "s"
     error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'."
   }
 }

--- a/gcs-egress-monitoring/variables.tf
+++ b/gcs-egress-monitoring/variables.tf
@@ -19,7 +19,7 @@ variable "sent_bytes_alerting_duration" {
 }
 
 variable "sent_bytes_alerting_alignment_period" {
-  type = string
+  type        = string
   description = "The number of seconds to use for the alignment period when evaluating an alert condition. As a string, 60 seconds would be represented as '60s'"
 
 }
@@ -27,4 +27,5 @@ variable "sent_bytes_alerting_alignment_period" {
 variable "notification_channels" {
   type        = list(string)
   description = "A list of notification channel IDs. These should be defined in your project's configuration, and supplied here as an input to the module"
+  default     = []
 }

--- a/gcs-egress-monitoring/variables.tf
+++ b/gcs-egress-monitoring/variables.tf
@@ -16,12 +16,19 @@ variable "sent_bytes_alerting_threshold" {
 variable "sent_bytes_alerting_duration" {
   type        = string
   description = "The number of seconds to evaluate an alert threshold on. As a string, 60 seconds would be represented as '60s'"
+  validation {
+    condition = substr(var.image_id, -2, -1) == "s"
+    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'"
+  }
 }
 
 variable "sent_bytes_alerting_alignment_period" {
   type        = string
   description = "The number of seconds to use for the alignment period when evaluating an alert condition. As a string, 60 seconds would be represented as '60s'"
-
+  validation {
+    condition = substr(var.image_id, -2, -1) == "s"
+    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'"
+  }
 }
 
 variable "notification_channels" {

--- a/gcs-egress-monitoring/variables.tf
+++ b/gcs-egress-monitoring/variables.tf
@@ -18,7 +18,7 @@ variable "sent_bytes_alerting_duration" {
   description = "The number of seconds to evaluate an alert threshold on. As a string, 60 seconds would be represented as '60s'"
   validation {
     condition     = substr(var.sent_bytes_alerting_duration, -1, -1) == "s"
-    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'."
+    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'; e.g. '100s'."
   }
 }
 
@@ -27,7 +27,7 @@ variable "sent_bytes_alerting_alignment_period" {
   description = "The number of seconds to use for the alignment period when evaluating an alert condition. As a string, 60 seconds would be represented as '60s'"
   validation {
     condition     = substr(var.sent_bytes_alerting_alignment_period, -1, -1) == "s"
-    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'."
+    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'; e.g. '100s'."
   }
 }
 

--- a/gcs-egress-monitoring/variables.tf
+++ b/gcs-egress-monitoring/variables.tf
@@ -17,8 +17,8 @@ variable "sent_bytes_alerting_duration" {
   type        = string
   description = "The number of seconds to evaluate an alert threshold on. As a string, 60 seconds would be represented as '60s'"
   validation {
-    condition = substr(var.image_id, -2, -1) == "s"
-    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'"
+    condition     = substr(var.sent_bytes_alerting_duration, -2, -1) == "s"
+    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'."
   }
 }
 
@@ -26,8 +26,8 @@ variable "sent_bytes_alerting_alignment_period" {
   type        = string
   description = "The number of seconds to use for the alignment period when evaluating an alert condition. As a string, 60 seconds would be represented as '60s'"
   validation {
-    condition = substr(var.image_id, -2, -1) == "s"
-    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'"
+    condition     = substr(var.sent_bytes_alerting_alignment_period, -2, -1) == "s"
+    error_message = "The time format must be a string, with the number of seconds, ending in the letter 's'."
   }
 }
 


### PR DESCRIPTION
This module configures a google monitoring alert policy, which can send notifications when the bytes_sent metric on a bucket breaches a provided threshold.