### PR TITLE
Import seqr-gke modules

### DIFF
--- a/seqr-gke-nodepool/main.tf
+++ b/seqr-gke-nodepool/main.tf
@@ -1,0 +1,43 @@
+resource "google_container_node_pool" "node_pool" {
+  cluster  = var.cluster_name
+  location = var.node_location
+
+  management {
+    auto_repair  = "true"
+    auto_upgrade = "true"
+  }
+
+  name = var.node_pool_name
+
+  node_config {
+    disk_size_gb = "100"
+    disk_type    = "pd-standard"
+    image_type   = var.node_pool_image_type
+
+    labels = var.node_pool_labels
+
+    local_ssd_count = "0"
+    machine_type    = var.node_pool_machine_type
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes    = ["https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write"]
+    preemptible     = var.preemptible_nodes
+    service_account = "default"
+
+    shielded_instance_config {
+      enable_integrity_monitoring = "true"
+      enable_secure_boot          = "false"
+    }
+  }
+
+  node_count     = var.node_pool_count
+  node_locations = [var.node_location]
+
+  upgrade_settings {
+    max_surge       = "1"
+    max_unavailable = "0"
+  }
+}

--- a/seqr-gke-nodepool/variables.tf
+++ b/seqr-gke-nodepool/variables.tf
@@ -1,0 +1,36 @@
+variable "node_pool_count" {
+  type = string
+}
+
+variable "node_location" {
+  type    = string
+  default = "us-central1-b"
+}
+
+variable "preemptible_nodes" {
+  type    = bool
+  default = false
+}
+
+variable "node_pool_labels" {
+  type    = map(string)
+  default = {}
+}
+variable "node_pool_name" {
+  type = string
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster that the node pool should reside in."
+}
+
+variable "node_pool_machine_type" {
+  type = string
+}
+
+variable "node_pool_image_type" {
+  type        = string
+  description = "The GKE image to use for the node pool. Should usually be COS_CONTAINERD."
+  default     = "COS_CONTAINERD"
+}

--- a/seqr-gke/main.tf
+++ b/seqr-gke/main.tf
@@ -1,0 +1,190 @@
+# Main cluster configuration
+resource "google_container_cluster" "cluster" {
+  name                        = var.cluster_name
+  project                     = var.project
+  monitoring_service          = "monitoring.googleapis.com/kubernetes"
+  network                     = "projects/${var.project}/global/networks/default"
+  subnetwork                  = "projects/${var.project}/regions/us-central1/subnetworks/default"
+  cluster_ipv4_cidr           = var.cluster_ipv4_cidr
+  default_max_pods_per_node   = "110"
+  enable_binary_authorization = "false"
+  enable_intranode_visibility = "false"
+  enable_kubernetes_alpha     = "false"
+  enable_legacy_abac          = "false"
+  enable_shielded_nodes       = "false"
+  enable_tpu                  = "false"
+  initial_node_count          = var.cluster_initial_node_count
+  location                    = var.cluster_location
+  logging_service             = "logging.googleapis.com/kubernetes"
+  networking_mode             = var.networking_mode
+  remove_default_node_pool    = var.remove_default_node_pool
+
+  addons_config {
+    cloudrun_config {
+      disabled = "true"
+    }
+
+    http_load_balancing {
+      disabled = "false"
+    }
+
+    network_policy_config {
+      disabled = "true"
+    }
+  }
+
+  cluster_autoscaling {
+    enabled = "false"
+  }
+
+
+  database_encryption {
+    state = "DECRYPTED"
+  }
+
+  maintenance_policy {
+    dynamic "recurring_window" {
+      for_each = var.recurring_maint_windows
+      content {
+        start_time = recurring_window.value.start_time
+        end_time   = recurring_window.value.end_time
+        recurrence = recurring_window.value.recurrence
+      }
+    }
+
+    dynamic "maintenance_exclusion" {
+      for_each = var.maint_exclusions
+      content {
+        start_time     = maintenance_exclusion.value.start_time
+        end_time       = maintenance_exclusion.value.end_time
+        exclusion_name = maintenance_exclusion.value.name
+
+      }
+    }
+  }
+
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = "false"
+    }
+  }
+
+  master_authorized_networks_config {
+    cidr_blocks {
+      cidr_block = "69.173.127.192/27"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.112.0/21"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.96.0/20"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.127.232/29"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.126.0/24"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.124.0/23"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.127.0/25"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.64.0/19"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.127.228/32"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.127.224/30"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.127.240/28"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.127.230/31"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.127.128/26"
+    }
+
+    cidr_blocks {
+      cidr_block = "69.173.120.0/22"
+    }
+  }
+
+  network_policy {
+    enabled  = "false"
+    provider = "PROVIDER_UNSPECIFIED"
+  }
+
+
+  release_channel {
+    channel = "UNSPECIFIED"
+  }
+
+  dynamic "workload_identity_config" {
+    for_each = var.workload_identity
+    content {
+      workload_pool = workload_identity_config.value.name
+    }
+  }
+
+  resource_labels = var.gke_resource_labels
+}
+
+# Default node pool configuration
+resource "google_container_node_pool" "default_pool" {
+  project  = var.project
+  cluster  = google_container_cluster.cluster.name
+  location = var.cluster_location
+
+  management {
+    auto_repair  = "true"
+    auto_upgrade = "true"
+  }
+
+  name = "default-pool"
+
+  node_config {
+    disk_size_gb    = var.default_pool_disk_size
+    disk_type       = "pd-standard"
+    image_type      = var.default_pool_image_type
+    local_ssd_count = "0"
+    machine_type    = var.default_pool_machine_type
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes    = ["https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write"]
+    preemptible     = "false"
+    service_account = "default"
+
+    shielded_instance_config {
+      enable_integrity_monitoring = "true"
+      enable_secure_boot          = "false"
+    }
+  }
+
+  node_count = var.default_pool_node_count
+
+  upgrade_settings {
+    max_surge       = "1"
+    max_unavailable = "0"
+  }
+}

--- a/seqr-gke/outputs.tf
+++ b/seqr-gke/outputs.tf
@@ -1,0 +1,3 @@
+output "gke-cluster-name" {
+  value = google_container_cluster.cluster.name
+}

--- a/seqr-gke/variables.tf
+++ b/seqr-gke/variables.tf
@@ -1,0 +1,84 @@
+variable "cluster_name" {
+  type        = string
+  description = "The name of your GKE cluster"
+}
+
+variable "cluster_ipv4_cidr" {
+  type        = string
+  description = "The network CIDR that's used for the pod network"
+}
+
+variable "cluster_location" {
+  type        = string
+  description = "The GCP region where your cluster runs. E.g. us-central1-c"
+}
+
+variable "default_pool_machine_type" {
+  type        = string
+  description = "The GCP machine type that should be used for the default pool"
+}
+
+variable "default_pool_node_count" {
+  type        = number
+  description = "The number of nodes that should be contained in the default pool"
+}
+
+variable "remove_default_node_pool" {
+  type        = bool
+  default     = true
+  description = "value"
+}
+
+variable "cluster_initial_node_count" {
+  type        = number
+  description = "The number of nodes that should be created in the cluster's initial default pool"
+  default     = "0"
+}
+
+variable "default_pool_disk_size" {
+  type        = number
+  description = "The size of the default pool disk in gb"
+  default     = "100"
+}
+
+# Default to daily 3AM-7AM Eastern time maintenance window
+variable "recurring_maint_windows" {
+  type = list(map(string))
+  default = [{
+    start_time = "1970-01-01T07:00:00Z"
+    end_time   = "1970-01-01T11:00:00Z"
+    recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU"
+  }]
+}
+
+variable "maint_exclusions" {
+  type    = list(map(string))
+  default = []
+}
+
+variable "networking_mode" {
+  type    = string
+  default = "ROUTES"
+}
+
+variable "project" {
+  type        = string
+  description = "The name of your GCP project"
+  default     = "seqr-project"
+}
+
+variable "gke_resource_labels" {
+  type    = map(string)
+  default = {}
+}
+
+variable "workload_identity" {
+  type    = list(map(string))
+  default = []
+}
+
+variable "default_pool_image_type" {
+  type        = string
+  description = "The GKE image to use for the default node pool. Should generally be COS_CONTAINERD unless you specifically need something else."
+  default     = "COS_CONTAINERD"
+}


### PR DESCRIPTION
Importing the seqr GKE modules here, so that they can be versioned and tagged independently of the rest of the seqr terraform configuration.

Currently, the modules are hosted in seqr-terraform, and the seqr environments reference them as a relative path, like: `source = "../modules/seqr-gke"`

This is problematic, because once we change one of the modules, it then will modify all of the environments the next time we try to apply it, whether or not that env is ready for the change. This causes us to leave terraform PRs open until all the environments that are affected by a given change have been updated.

By hosting them here, each environment can reference a specific commit/tag of the module, like this: `source  = "github.com/broadinstitute/tgg-terraform-modules//seqr-gke?ref=1679ea8bb0fedfb879bca581624c6c51df6efbfa"`

This will let us to per-env PRs, and work on module updates in a way that allows us to update an environment only when it is ready.