### PR TITLE
Add policy options to external-secrets

### DIFF
--- a/external-secrets/main.tf
+++ b/external-secrets/main.tf
@@ -1,7 +1,7 @@
 # The IAM role that we'll use to allow read access to all GCP secrets within the project
 resource "google_project_iam_custom_role" "external-secrets-gsa" {
-  role_id     = "${app_name}_${var.env}_external_secrets"
-  title       = "${app_name} ${var.env} Secret Manager Read Access"
+  role_id     = "${var.app_name}_${var.env}_external_secrets"
+  title       = "${var.app_name} ${var.env} Secret Manager Read Access"
   description = "intended to allow the external-secrets controller to access secrets"
   permissions = [
     "resourcemanager.projects.get",
@@ -18,8 +18,8 @@ resource "google_project_iam_custom_role" "external-secrets-gsa" {
 
 # The ServiceAccount that the external-secrets controller will use to identify itself to the GCP API.
 resource "google_service_account" "external-secrets" {
-  account_id   = "${app_name}-${var.env}-external-secrets"
-  display_name = "${app_name} ${var.env} External Secrets Controller"
+  account_id   = "${var.app_name}-${var.env}-external-secrets"
+  display_name = "${var.app_name} ${var.env} External Secrets Controller"
 }
 
 # Bind the ServiceAccount to the IAM role.

--- a/external-secrets/main.tf
+++ b/external-secrets/main.tf
@@ -26,6 +26,17 @@ resource "google_service_account" "external-secrets" {
 resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
   role   = google_project_iam_custom_role.external-secrets-gsa.name
   member = "serviceAccount:${google_service_account.external-secrets.email}"
+
+  dynamic "iam_condition" {
+    for_each = var.iam_conditions
+    content {
+      condition {
+        title       = iam_condition.value.title
+        description = iam_condition.value.description
+        expression  = iam_condition.value.expression
+      }
+    }
+  }
 }
 
 # Generate a key for the ServiceAccount, for the controller to authenticate with

--- a/external-secrets/main.tf
+++ b/external-secrets/main.tf
@@ -34,9 +34,9 @@ resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
   dynamic "condition" {
     for_each = var.iam_conditions
     content {
-      title       = iam_condition.title.value
-      description = iam_condition.description.value
-      expression  = iam_condition.expression.value
+      title       = condition.value.title
+      description = condition.value.description
+      expression  = condition.value.expression
     }
   }
 }

--- a/external-secrets/main.tf
+++ b/external-secrets/main.tf
@@ -23,9 +23,13 @@ resource "google_service_account" "external-secrets" {
 }
 
 # Bind the ServiceAccount to the IAM role.
+
+data "google_project" "current_project" {}
+
 resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
   role   = google_project_iam_custom_role.external-secrets-gsa.name
   member = "serviceAccount:${google_service_account.external-secrets.email}"
+  project = data.google_project.current_project.project_id
 
   dynamic "condition" {
     for_each = var.iam_conditions

--- a/external-secrets/main.tf
+++ b/external-secrets/main.tf
@@ -27,14 +27,12 @@ resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
   role   = google_project_iam_custom_role.external-secrets-gsa.name
   member = "serviceAccount:${google_service_account.external-secrets.email}"
 
-  dynamic "iam_condition" {
+  dynamic "condition" {
     for_each = var.iam_conditions
     content {
-      condition {
-        title       = iam_condition.value.title
-        description = iam_condition.value.description
-        expression  = iam_condition.value.expression
-      }
+      title       = iam_condition.value.title
+      description = iam_condition.value.description
+      expression  = iam_condition.value.expression
     }
   }
 }

--- a/external-secrets/main.tf
+++ b/external-secrets/main.tf
@@ -34,9 +34,9 @@ resource "google_project_iam_member" "k8s-external-secrets-iam-membership" {
   dynamic "condition" {
     for_each = var.iam_conditions
     content {
-      title       = iam_condition.value.title
-      description = iam_condition.value.description
-      expression  = iam_condition.value.expression
+      title       = iam_condition.title.value
+      description = iam_condition.description.value
+      expression  = iam_condition.expression.value
     }
   }
 }

--- a/external-secrets/variables.tf
+++ b/external-secrets/variables.tf
@@ -7,3 +7,9 @@ variable "env" {
   type        = string
   description = "The name of the environment we are deploying to. E.g. {dev,stage,prod}"
 }
+
+variable "iam_conditions" {
+  type = list(map(string))
+  default = []
+  description = "A list of IAM conditions to be applied to the external-secrets service account role binding"
+}


### PR DESCRIPTION
This allows users to specify additional IAM conditions to the external-secrets module's IAM role binding. The use case, is that this allows you to define restrictions on what secrets the Service Account is allowed to access. By default, the IAM service account can access all secrets in the project that it's deployed in, but you might want to limit it to accessing secrets that begin with a given prefix.