### PR TITLE
adds a module for granting users scoped dataproc access

### DIFF
--- a/dataproc-service-acct/README.md
+++ b/dataproc-service-acct/README.md
@@ -1,0 +1,26 @@
+# Dataproc Service Accounts
+
+To allow users to run dataproc in a GCP project with limited access to storage, we need to provide several things:
+
+- A service account to run the dataproc cluster with, so that the user doesn't need access to the default compute service account
+- An IAM grant that allows the user to ActAs that service account
+- stage and temp buckets for dataproc, which the service account and user both have write access to
+
+## Inputs
+
+- We need the user principal
+- We need the name / id that we should use for the service account
+- We need the name of the two buckets (or, maybe just a single prefix to use for both)
+
+## Outputs
+
+This module returns:
+- the email address of the new service account
+- The names of the two buckets
+
+
+With this information, you should:
+
+- Grant the least-privileged dataproc worker role to the service account
+- Grant the user dataproc.editor
+- Grant the user and service accounts the storage access that they need

--- a/dataproc-service-acct/main.tf
+++ b/dataproc-service-acct/main.tf
@@ -1,0 +1,56 @@
+resource "google_service_account" "dataproc_service_account" {
+  project      = module.test_project.project_identifier
+  account_id   = var.service_account_id
+  display_name = var.service_account_display_name
+}
+
+resource "google_service_account_iam_binding" "grant_sa_usage" {
+  service_account_id = google_service_account.dataproc_service_account.id
+  role               = "roles/iam.serviceAccountUser"
+
+  members = ["user:${var.user_principal}"]
+}
+
+resource "google_project_iam_member" "grant_dataproc_editor" {
+  project = module.test_project.project_identifier
+  role    = "roles/dataproc.editor"
+  member  = "user:${var.user_principal}"
+}
+
+resource "google_storage_bucket" "user_dataproc_stage" {
+  project       = module.test_project.project_identifier
+  name          = "${var.dataproc_bucket_prefix}-stage"
+  storage_class = "STANDARD"
+  location      = "us-central1"
+}
+
+resource "google_storage_bucket" "user_dataproc_temp" {
+  project       = module.test_project.project_identifier
+  name          = "${var.dataproc_bucket_prefix}-temp"
+  storage_class = "STANDARD"
+  location      = "us-central1"
+}
+
+resource "google_storage_bucket_iam_member" "grant_user_dataproc_stage_write" {
+  bucket = google_storage_bucket.user_dataproc_stage.name
+  role   = "roles/storage.objectAdmin"
+  member = "user:${var.user_principal}"
+}
+
+resource "google_storage_bucket_iam_member" "grant_user_dataproc_temp_write" {
+  bucket = google_storage_bucket.user_dataproc_temp.name
+  role   = "roles/storage.objectAdmin"
+  member = "user:${var.user_principal}"
+}
+
+resource "google_storage_bucket_iam_member" "dataproc_sa_stage_write" {
+  bucket = google_storage_bucket.user_dataproc_stage.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.dataproc_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "dataproc_sa_temp_write" {
+  bucket = google_storage_bucket.user_dataproc_temp.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.dataproc_service_account.email}"
+}

--- a/dataproc-service-acct/main.tf
+++ b/dataproc-service-acct/main.tf
@@ -22,6 +22,7 @@ resource "google_storage_bucket" "user_dataproc_stage" {
   name          = "${var.dataproc_bucket_prefix}-stage"
   storage_class = "STANDARD"
   location      = "us-central1"
+  force_destroy = var.force_destroy_user_dataproc_buckets
 }
 
 resource "google_storage_bucket" "user_dataproc_temp" {
@@ -29,6 +30,7 @@ resource "google_storage_bucket" "user_dataproc_temp" {
   name          = "${var.dataproc_bucket_prefix}-temp"
   storage_class = "STANDARD"
   location      = "us-central1"
+  force_destroy = var.force_destroy_user_dataproc_buckets
 }
 
 resource "google_storage_bucket_iam_member" "grant_user_dataproc_stage_write" {

--- a/dataproc-service-acct/outputs.tf
+++ b/dataproc-service-acct/outputs.tf
@@ -1,0 +1,11 @@
+output "service_account_email" {
+  value = google_service_account.dataproc_service_account.email
+}
+
+output "dataproc_temp_bucket_name" {
+  value = google_storage_bucket.user_dataproc_temp.name
+}
+
+output "dataproc_stage_bucket_name" {
+  value = google_storage_bucket.user_dataproc_stage.name
+}

--- a/dataproc-service-acct/variables.tf
+++ b/dataproc-service-acct/variables.tf
@@ -1,0 +1,19 @@
+variable "user_principal" {
+  type        = string
+  description = "The email address of the user we'd like to grant access to"
+}
+
+variable "service_account_id" {
+  type        = string
+  description = "The name that we should use as the username portion of the service account email address"
+}
+
+variable "service_account_display_name" {
+  type        = string
+  description = "The display name of the service account that we are going to create"
+}
+
+variable "dataproc_bucket_prefix" {
+  type        = string
+  description = "The prefix that we should use for the names of the stage and temp buckets for Dataproc."
+}

--- a/dataproc-service-acct/variables.tf
+++ b/dataproc-service-acct/variables.tf
@@ -17,3 +17,8 @@ variable "dataproc_bucket_prefix" {
   type        = string
   description = "The prefix that we should use for the names of the stage and temp buckets for Dataproc."
 }
+
+variable "force_destroy_user_dataproc_buckets" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
In order to let someone use dataproc in a GCP project without granting them either access to the default compute service account, or read/write access to all GCS storage (The default dataproc.worker role does this), we need to create a custom role, and then grant it to a user and their service account. There's also a few other things needed to prevent needing to grant access to other storage entities, including creating a few buckets for the user to use for dataproc jobs.

This module creates a service account and GCS buckets, and then grants the specified user ActAs permissions on the service account, and read/write access to the new GCS buckets.

You can then grant the user and service account access to other resources as needed in your project IAM configuration.