### PR TITLE
Add optional permissions for cases where the user has a hail batch account

### DIFF
--- a/gnomad-google-project/README.md
+++ b/gnomad-google-project/README.md
@@ -53,68 +53,72 @@ When creating a GCP project for collaboration, the following actions are typical
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name                                                             | Version   |
-| ---------------------------------------------------------------- | --------- |
+| Name | Version |
+|------|---------|
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2  |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2 |
 
 ## Providers
 
-| Name                                                       | Version   |
-| ---------------------------------------------------------- | --------- |
+| Name | Version |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 4.42.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2  |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2 |
 
 ## Modules
 
-| Name                                                                                                         | Source                                                                    | Version |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ------- |
-| <a name="module_default-project-services"></a> [default-project-services](#module\_default-project-services) | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0  |
-| <a name="module_project-services"></a> [project-services](#module\_project-services)                         | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0  |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_default-project-services"></a> [default-project-services](#module\_default-project-services) | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0 |
+| <a name="module_project-services"></a> [project-services](#module\_project-services) | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0 |
 
 ## Resources
 
-| Name                                                                                                                                                                      | Type        |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [google_compute_firewall.allow_ssh_broad_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)                         | resource    |
-| [google_compute_firewall.dataproc_internal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)                              | resource    |
-| [google_compute_firewall.iap_forwarding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)                                 | resource    |
-| [google_compute_network.project_network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network)                                  | resource    |
-| [google_project.current_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project)                                                  | resource    |
-| [google_project_iam_custom_role.bucket_list_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role)                 | resource    |
-| [google_project_iam_member.default_compute_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                      | resource    |
-| [google_project_iam_member.default_compute_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                | resource    |
-| [google_project_iam_member.default_compute_dataproc_worker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)            | resource    |
-| [google_project_iam_member.default_compute_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)               | resource    |
-| [google_project_iam_member.default_compute_service_usage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)              | resource    |
-| [google_project_iam_member.owner_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                                | resource    |
-| [google_project_iam_member.primary_iap_tunnel_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                  | resource    |
-| [google_project_iam_member.primary_user_editor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                        | resource    |
-| [google_storage_bucket.general_use_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket)                                 | resource    |
-| [google_storage_bucket.tmp_4day_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket)                                    | resource    |
-| [random_id.random_project_id_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id)                                                   | resource    |
+| Name | Type |
+|------|------|
+| [google_compute_firewall.allow_ssh_broad_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.dataproc_internal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.iap_forwarding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_network.project_network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
+| [google_project.current_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project) | resource |
+| [google_project_iam_custom_role.bucket_list_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.default_compute_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.default_compute_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.default_compute_dataproc_worker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.default_compute_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.default_compute_service_usage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.hail_batch_artifact_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.hail_batch_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.hail_batch_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.owner_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.primary_iap_tunnel_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.primary_user_editor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_storage_bucket.general_use_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket.tmp_4day_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [random_id.random_project_id_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google_storage_bucket_object_content.internal_networks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_bucket_object_content) | data source |
 
 ## Inputs
 
-| Name                                                                                                                                        | Description                                                                                                                                                                                               | Type           | Default         | Required |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | --------------- | :------: |
-| <a name="input_allow_broad_inst_ssh_access"></a> [allow\_broad\_inst\_ssh\_access](#input\_allow\_broad\_inst\_ssh\_access)                 | Whether to create a firewall rule that allows access to TCP port 22 from Broad Institute networks.                                                                                                        | `bool`         | `true`          |    no    |
-| <a name="input_apis_to_enable"></a> [apis\_to\_enable](#input\_apis\_to\_enable)                                                            | The list of additional APIs to enable. We always enable dataproc and cloudfunctions.                                                                                                                      | `list(string)` | `[]`            |    no    |
-| <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id)                                                | The ID of the billing account that the project should be associated with.                                                                                                                                 | `string`       | n/a             |   yes    |
-| <a name="input_configure_dataproc_firewall_rules"></a> [configure\_dataproc\_firewall\_rules](#input\_configure\_dataproc\_firewall\_rules) | Whether we should configure firewall rules to allow all traffic between nodes tagged 'dataproc-node'. If you intend to use dataproc, you will need this.                                                  | `bool`         | `true`          |    no    |
-| <a name="input_create_default_buckets"></a> [create\_default\_buckets](#input\_create\_default\_buckets)                                    | Specifies whether to create default general-use and tmp with 4-day auto-delete lifecycle buckets.                                                                                                         | `bool`         | `true`          |    no    |
-| <a name="input_default_resource_region"></a> [default\_resource\_region](#input\_default\_resource\_region)                                 | For managed items that require a region/location                                                                                                                                                          | `string`       | `"us-central1"` |    no    |
-| <a name="input_enable_default_services"></a> [enable\_default\_services](#input\_enable\_default\_services)                                 | Whether or not to enable the default cloudfunction or dataproc services. Set to false if you don't want to enable these, or if you want to manage them via apis\_to\_enable.                              | `bool`         | `true`          |    no    |
-| <a name="input_gcp_folder_id"></a> [gcp\_folder\_id](#input\_gcp\_folder\_id)                                                               | The ID numder of the GCP Organization folder to place the project in.                                                                                                                                     | `string`       | n/a             |   yes    |
-| <a name="input_owner_group_id"></a> [owner\_group\_id](#input\_owner\_group\_id)                                                            | The email address for the group you would like to grant Owner access on the project.                                                                                                                      | `string`       | n/a             |   yes    |
-| <a name="input_primary_user_principal"></a> [primary\_user\_principal](#input\_primary\_user\_principal)                                    | The primary user/group of the GCP project. This grants Editor access, and other permissions generally required to use services. Provide a IAM principal style {group/user/serviceAccount}:{email} string. | `string`       | n/a             |   yes    |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id)                                                                          | The string that should be used to create the unique ID google project; Will be suffixed with a random identifier.                                                                                         | `string`       | n/a             |   yes    |
-| <a name="input_project_name"></a> [project\_name](#input\_project\_name)                                                                    | The human readable name of the project. Does not need to be unique.                                                                                                                                       | `string`       | n/a             |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_broad_inst_ssh_access"></a> [allow\_broad\_inst\_ssh\_access](#input\_allow\_broad\_inst\_ssh\_access) | Whether to create a firewall rule that allows access to TCP port 22 from Broad Institute networks. | `bool` | `true` | no |
+| <a name="input_apis_to_enable"></a> [apis\_to\_enable](#input\_apis\_to\_enable) | The list of additional APIs to enable. We always enable dataproc and cloudfunctions. | `list(string)` | `[]` | no |
+| <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id) | The ID of the billing account that the project should be associated with. | `string` | n/a | yes |
+| <a name="input_configure_dataproc_firewall_rules"></a> [configure\_dataproc\_firewall\_rules](#input\_configure\_dataproc\_firewall\_rules) | Whether we should configure firewall rules to allow all traffic between nodes tagged 'dataproc-node'. If you intend to use dataproc, you will need this. | `bool` | `true` | no |
+| <a name="input_create_default_buckets"></a> [create\_default\_buckets](#input\_create\_default\_buckets) | Specifies whether to create default general-use and tmp with 4-day auto-delete lifecycle buckets. | `bool` | `true` | no |
+| <a name="input_default_resource_region"></a> [default\_resource\_region](#input\_default\_resource\_region) | For managed items that require a region/location | `string` | `"us-central1"` | no |
+| <a name="input_enable_default_services"></a> [enable\_default\_services](#input\_enable\_default\_services) | Whether or not to enable the default cloudfunction or dataproc services. Set to false if you don't want to enable these, or if you want to manage them via apis\_to\_enable. | `bool` | `true` | no |
+| <a name="input_gcp_folder_id"></a> [gcp\_folder\_id](#input\_gcp\_folder\_id) | The ID numder of the GCP Organization folder to place the project in. | `string` | n/a | yes |
+| <a name="input_hail_batch_service_account"></a> [hail\_batch\_service\_account](#input\_hail\_batch\_service\_account) | The email address of a Hail Batch service account, to be granted storage and docker registry access. | `string` | `""` | no |
+| <a name="input_owner_group_id"></a> [owner\_group\_id](#input\_owner\_group\_id) | The email address for the group you would like to grant Owner access on the project. | `string` | n/a | yes |
+| <a name="input_primary_user_principal"></a> [primary\_user\_principal](#input\_primary\_user\_principal) | The primary user/group of the GCP project. This grants Editor access, and other permissions generally required to use services. Provide a IAM principal style {group/user/serviceAccount}:{email} string. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The string that should be used to create the unique ID google project; Will be suffixed with a random identifier. | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The human readable name of the project. Does not need to be unique. | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                                                                                         | Description |
-| -------------------------------------------------------------------------------------------- | ----------- |
-| <a name="output_project_identifier"></a> [project\_identifier](#output\_project\_identifier) | n/a         |
+| Name | Description |
+|------|-------------|
+| <a name="output_project_identifier"></a> [project\_identifier](#output\_project\_identifier) | n/a |
 <!-- END_TF_DOCS -->

--- a/gnomad-google-project/README.md
+++ b/gnomad-google-project/README.md
@@ -18,6 +18,14 @@ This module is designed to easily spin up a google cloud project in a configurat
   - compute.admin
   - dataproc.worker
   - storage.objectAdmin
+  - serviceusage.serviceUsageConsumer
+- For the provided Primary User, grant the following IAM roles:
+  - artifactregistry.admin
+  - editor
+  - iap.tunnelResourceAccessor
+- If a hail batch service account is provided, grant the following IAM roles:
+  - storage.objectAdmin
+  - artifactregistry.read
 
 ## Project Ownership
 
@@ -53,72 +61,72 @@ When creating a GCP project for collaboration, the following actions are typical
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
+| Name                                                             | Version   |
+| ---------------------------------------------------------------- | --------- |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
+| Name                                                       | Version   |
+| ---------------------------------------------------------- | --------- |
 | <a name="provider_google"></a> [google](#provider\_google) | >= 4.42.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2  |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_default-project-services"></a> [default-project-services](#module\_default-project-services) | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0 |
-| <a name="module_project-services"></a> [project-services](#module\_project-services) | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0 |
+| Name                                                                                                         | Source                                                                    | Version |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ------- |
+| <a name="module_default-project-services"></a> [default-project-services](#module\_default-project-services) | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0  |
+| <a name="module_project-services"></a> [project-services](#module\_project-services)                         | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0  |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [google_compute_firewall.allow_ssh_broad_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
-| [google_compute_firewall.dataproc_internal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
-| [google_compute_firewall.iap_forwarding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
-| [google_compute_network.project_network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
-| [google_project.current_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project) | resource |
-| [google_project_iam_custom_role.bucket_list_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
-| [google_project_iam_member.default_compute_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.default_compute_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.default_compute_dataproc_worker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.default_compute_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.default_compute_service_usage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.hail_batch_artifact_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.hail_batch_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.hail_batch_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.owner_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.primary_iap_tunnel_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.primary_user_editor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_storage_bucket.general_use_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
-| [google_storage_bucket.tmp_4day_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
-| [random_id.random_project_id_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| Name                                                                                                                                                                      | Type        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [google_compute_firewall.allow_ssh_broad_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)                         | resource    |
+| [google_compute_firewall.dataproc_internal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)                              | resource    |
+| [google_compute_firewall.iap_forwarding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)                                 | resource    |
+| [google_compute_network.project_network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network)                                  | resource    |
+| [google_project.current_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project)                                                  | resource    |
+| [google_project_iam_custom_role.bucket_list_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role)                 | resource    |
+| [google_project_iam_member.default_compute_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                      | resource    |
+| [google_project_iam_member.default_compute_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                | resource    |
+| [google_project_iam_member.default_compute_dataproc_worker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)            | resource    |
+| [google_project_iam_member.default_compute_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)               | resource    |
+| [google_project_iam_member.default_compute_service_usage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)              | resource    |
+| [google_project_iam_member.hail_batch_artifact_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                   | resource    |
+| [google_project_iam_member.hail_batch_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                     | resource    |
+| [google_project_iam_member.hail_batch_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                    | resource    |
+| [google_project_iam_member.owner_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                                | resource    |
+| [google_project_iam_member.primary_iap_tunnel_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                  | resource    |
+| [google_project_iam_member.primary_user_editor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                        | resource    |
+| [google_storage_bucket.general_use_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket)                                 | resource    |
+| [google_storage_bucket.tmp_4day_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket)                                    | resource    |
+| [random_id.random_project_id_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id)                                                   | resource    |
 | [google_storage_bucket_object_content.internal_networks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_bucket_object_content) | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_allow_broad_inst_ssh_access"></a> [allow\_broad\_inst\_ssh\_access](#input\_allow\_broad\_inst\_ssh\_access) | Whether to create a firewall rule that allows access to TCP port 22 from Broad Institute networks. | `bool` | `true` | no |
-| <a name="input_apis_to_enable"></a> [apis\_to\_enable](#input\_apis\_to\_enable) | The list of additional APIs to enable. We always enable dataproc and cloudfunctions. | `list(string)` | `[]` | no |
-| <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id) | The ID of the billing account that the project should be associated with. | `string` | n/a | yes |
-| <a name="input_configure_dataproc_firewall_rules"></a> [configure\_dataproc\_firewall\_rules](#input\_configure\_dataproc\_firewall\_rules) | Whether we should configure firewall rules to allow all traffic between nodes tagged 'dataproc-node'. If you intend to use dataproc, you will need this. | `bool` | `true` | no |
-| <a name="input_create_default_buckets"></a> [create\_default\_buckets](#input\_create\_default\_buckets) | Specifies whether to create default general-use and tmp with 4-day auto-delete lifecycle buckets. | `bool` | `true` | no |
-| <a name="input_default_resource_region"></a> [default\_resource\_region](#input\_default\_resource\_region) | For managed items that require a region/location | `string` | `"us-central1"` | no |
-| <a name="input_enable_default_services"></a> [enable\_default\_services](#input\_enable\_default\_services) | Whether or not to enable the default cloudfunction or dataproc services. Set to false if you don't want to enable these, or if you want to manage them via apis\_to\_enable. | `bool` | `true` | no |
-| <a name="input_gcp_folder_id"></a> [gcp\_folder\_id](#input\_gcp\_folder\_id) | The ID numder of the GCP Organization folder to place the project in. | `string` | n/a | yes |
-| <a name="input_hail_batch_service_account"></a> [hail\_batch\_service\_account](#input\_hail\_batch\_service\_account) | The email address of a Hail Batch service account, to be granted storage and docker registry access. | `string` | `""` | no |
-| <a name="input_owner_group_id"></a> [owner\_group\_id](#input\_owner\_group\_id) | The email address for the group you would like to grant Owner access on the project. | `string` | n/a | yes |
-| <a name="input_primary_user_principal"></a> [primary\_user\_principal](#input\_primary\_user\_principal) | The primary user/group of the GCP project. This grants Editor access, and other permissions generally required to use services. Provide a IAM principal style {group/user/serviceAccount}:{email} string. | `string` | n/a | yes |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The string that should be used to create the unique ID google project; Will be suffixed with a random identifier. | `string` | n/a | yes |
-| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The human readable name of the project. Does not need to be unique. | `string` | n/a | yes |
+| Name                                                                                                                                        | Description                                                                                                                                                                                               | Type           | Default         | Required |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | --------------- | :------: |
+| <a name="input_allow_broad_inst_ssh_access"></a> [allow\_broad\_inst\_ssh\_access](#input\_allow\_broad\_inst\_ssh\_access)                 | Whether to create a firewall rule that allows access to TCP port 22 from Broad Institute networks.                                                                                                        | `bool`         | `true`          |    no    |
+| <a name="input_apis_to_enable"></a> [apis\_to\_enable](#input\_apis\_to\_enable)                                                            | The list of additional APIs to enable. We always enable dataproc and cloudfunctions.                                                                                                                      | `list(string)` | `[]`            |    no    |
+| <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id)                                                | The ID of the billing account that the project should be associated with.                                                                                                                                 | `string`       | n/a             |   yes    |
+| <a name="input_configure_dataproc_firewall_rules"></a> [configure\_dataproc\_firewall\_rules](#input\_configure\_dataproc\_firewall\_rules) | Whether we should configure firewall rules to allow all traffic between nodes tagged 'dataproc-node'. If you intend to use dataproc, you will need this.                                                  | `bool`         | `true`          |    no    |
+| <a name="input_create_default_buckets"></a> [create\_default\_buckets](#input\_create\_default\_buckets)                                    | Specifies whether to create default general-use and tmp with 4-day auto-delete lifecycle buckets.                                                                                                         | `bool`         | `true`          |    no    |
+| <a name="input_default_resource_region"></a> [default\_resource\_region](#input\_default\_resource\_region)                                 | For managed items that require a region/location                                                                                                                                                          | `string`       | `"us-central1"` |    no    |
+| <a name="input_enable_default_services"></a> [enable\_default\_services](#input\_enable\_default\_services)                                 | Whether or not to enable the default cloudfunction or dataproc services. Set to false if you don't want to enable these, or if you want to manage them via apis\_to\_enable.                              | `bool`         | `true`          |    no    |
+| <a name="input_gcp_folder_id"></a> [gcp\_folder\_id](#input\_gcp\_folder\_id)                                                               | The ID numder of the GCP Organization folder to place the project in.                                                                                                                                     | `string`       | n/a             |   yes    |
+| <a name="input_hail_batch_service_account"></a> [hail\_batch\_service\_account](#input\_hail\_batch\_service\_account)                      | The email address of a Hail Batch service account, to be granted storage and docker registry access.                                                                                                      | `string`       | `""`            |    no    |
+| <a name="input_owner_group_id"></a> [owner\_group\_id](#input\_owner\_group\_id)                                                            | The email address for the group you would like to grant Owner access on the project.                                                                                                                      | `string`       | n/a             |   yes    |
+| <a name="input_primary_user_principal"></a> [primary\_user\_principal](#input\_primary\_user\_principal)                                    | The primary user/group of the GCP project. This grants Editor access, and other permissions generally required to use services. Provide a IAM principal style {group/user/serviceAccount}:{email} string. | `string`       | n/a             |   yes    |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id)                                                                          | The string that should be used to create the unique ID google project; Will be suffixed with a random identifier.                                                                                         | `string`       | n/a             |   yes    |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name)                                                                    | The human readable name of the project. Does not need to be unique.                                                                                                                                       | `string`       | n/a             |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_project_identifier"></a> [project\_identifier](#output\_project\_identifier) | n/a |
+| Name                                                                                         | Description |
+| -------------------------------------------------------------------------------------------- | ----------- |
+| <a name="output_project_identifier"></a> [project\_identifier](#output\_project\_identifier) | n/a         |
 <!-- END_TF_DOCS -->

--- a/gnomad-google-project/README.md
+++ b/gnomad-google-project/README.md
@@ -61,72 +61,73 @@ When creating a GCP project for collaboration, the following actions are typical
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name                                                             | Version   |
-| ---------------------------------------------------------------- | --------- |
+| Name | Version |
+|------|---------|
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2  |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2 |
 
 ## Providers
 
-| Name                                                       | Version   |
-| ---------------------------------------------------------- | --------- |
+| Name | Version |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 4.42.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2  |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2 |
 
 ## Modules
 
-| Name                                                                                                         | Source                                                                    | Version |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ------- |
-| <a name="module_default-project-services"></a> [default-project-services](#module\_default-project-services) | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0  |
-| <a name="module_project-services"></a> [project-services](#module\_project-services)                         | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0  |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_default-project-services"></a> [default-project-services](#module\_default-project-services) | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0 |
+| <a name="module_project-services"></a> [project-services](#module\_project-services) | terraform-google-modules/project-factory/google//modules/project_services | 13.0.0 |
 
 ## Resources
 
-| Name                                                                                                                                                                      | Type        |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [google_compute_firewall.allow_ssh_broad_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)                         | resource    |
-| [google_compute_firewall.dataproc_internal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)                              | resource    |
-| [google_compute_firewall.iap_forwarding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)                                 | resource    |
-| [google_compute_network.project_network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network)                                  | resource    |
-| [google_project.current_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project)                                                  | resource    |
-| [google_project_iam_custom_role.bucket_list_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role)                 | resource    |
-| [google_project_iam_member.default_compute_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                      | resource    |
-| [google_project_iam_member.default_compute_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                | resource    |
-| [google_project_iam_member.default_compute_dataproc_worker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)            | resource    |
-| [google_project_iam_member.default_compute_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)               | resource    |
-| [google_project_iam_member.default_compute_service_usage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)              | resource    |
-| [google_project_iam_member.hail_batch_artifact_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                   | resource    |
-| [google_project_iam_member.hail_batch_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                     | resource    |
-| [google_project_iam_member.hail_batch_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                    | resource    |
-| [google_project_iam_member.owner_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                                | resource    |
-| [google_project_iam_member.primary_iap_tunnel_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                  | resource    |
-| [google_project_iam_member.primary_user_editor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                        | resource    |
-| [google_storage_bucket.general_use_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket)                                 | resource    |
-| [google_storage_bucket.tmp_4day_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket)                                    | resource    |
-| [random_id.random_project_id_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id)                                                   | resource    |
+| Name | Type |
+|------|------|
+| [google_compute_firewall.allow_ssh_broad_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.dataproc_internal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.iap_forwarding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_network.project_network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
+| [google_project.current_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project) | resource |
+| [google_project_iam_custom_role.bucket_list_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.default_compute_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.default_compute_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.default_compute_dataproc_worker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.default_compute_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.default_compute_service_usage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.hail_batch_artifact_read](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.hail_batch_bucket_list](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.hail_batch_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.owner_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.primary_iap_tunnel_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.primary_user_artifact_reg_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.primary_user_editor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_storage_bucket.general_use_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket.tmp_4day_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [random_id.random_project_id_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google_storage_bucket_object_content.internal_networks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_bucket_object_content) | data source |
 
 ## Inputs
 
-| Name                                                                                                                                        | Description                                                                                                                                                                                               | Type           | Default         | Required |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | --------------- | :------: |
-| <a name="input_allow_broad_inst_ssh_access"></a> [allow\_broad\_inst\_ssh\_access](#input\_allow\_broad\_inst\_ssh\_access)                 | Whether to create a firewall rule that allows access to TCP port 22 from Broad Institute networks.                                                                                                        | `bool`         | `true`          |    no    |
-| <a name="input_apis_to_enable"></a> [apis\_to\_enable](#input\_apis\_to\_enable)                                                            | The list of additional APIs to enable. We always enable dataproc and cloudfunctions.                                                                                                                      | `list(string)` | `[]`            |    no    |
-| <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id)                                                | The ID of the billing account that the project should be associated with.                                                                                                                                 | `string`       | n/a             |   yes    |
-| <a name="input_configure_dataproc_firewall_rules"></a> [configure\_dataproc\_firewall\_rules](#input\_configure\_dataproc\_firewall\_rules) | Whether we should configure firewall rules to allow all traffic between nodes tagged 'dataproc-node'. If you intend to use dataproc, you will need this.                                                  | `bool`         | `true`          |    no    |
-| <a name="input_create_default_buckets"></a> [create\_default\_buckets](#input\_create\_default\_buckets)                                    | Specifies whether to create default general-use and tmp with 4-day auto-delete lifecycle buckets.                                                                                                         | `bool`         | `true`          |    no    |
-| <a name="input_default_resource_region"></a> [default\_resource\_region](#input\_default\_resource\_region)                                 | For managed items that require a region/location                                                                                                                                                          | `string`       | `"us-central1"` |    no    |
-| <a name="input_enable_default_services"></a> [enable\_default\_services](#input\_enable\_default\_services)                                 | Whether or not to enable the default cloudfunction or dataproc services. Set to false if you don't want to enable these, or if you want to manage them via apis\_to\_enable.                              | `bool`         | `true`          |    no    |
-| <a name="input_gcp_folder_id"></a> [gcp\_folder\_id](#input\_gcp\_folder\_id)                                                               | The ID numder of the GCP Organization folder to place the project in.                                                                                                                                     | `string`       | n/a             |   yes    |
-| <a name="input_hail_batch_service_account"></a> [hail\_batch\_service\_account](#input\_hail\_batch\_service\_account)                      | The email address of a Hail Batch service account, to be granted storage and docker registry access.                                                                                                      | `string`       | `""`            |    no    |
-| <a name="input_owner_group_id"></a> [owner\_group\_id](#input\_owner\_group\_id)                                                            | The email address for the group you would like to grant Owner access on the project.                                                                                                                      | `string`       | n/a             |   yes    |
-| <a name="input_primary_user_principal"></a> [primary\_user\_principal](#input\_primary\_user\_principal)                                    | The primary user/group of the GCP project. This grants Editor access, and other permissions generally required to use services. Provide a IAM principal style {group/user/serviceAccount}:{email} string. | `string`       | n/a             |   yes    |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id)                                                                          | The string that should be used to create the unique ID google project; Will be suffixed with a random identifier.                                                                                         | `string`       | n/a             |   yes    |
-| <a name="input_project_name"></a> [project\_name](#input\_project\_name)                                                                    | The human readable name of the project. Does not need to be unique.                                                                                                                                       | `string`       | n/a             |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_broad_inst_ssh_access"></a> [allow\_broad\_inst\_ssh\_access](#input\_allow\_broad\_inst\_ssh\_access) | Whether to create a firewall rule that allows access to TCP port 22 from Broad Institute networks. | `bool` | `true` | no |
+| <a name="input_apis_to_enable"></a> [apis\_to\_enable](#input\_apis\_to\_enable) | The list of additional APIs to enable. We always enable dataproc and cloudfunctions. | `list(string)` | `[]` | no |
+| <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id) | The ID of the billing account that the project should be associated with. | `string` | n/a | yes |
+| <a name="input_configure_dataproc_firewall_rules"></a> [configure\_dataproc\_firewall\_rules](#input\_configure\_dataproc\_firewall\_rules) | Whether we should configure firewall rules to allow all traffic between nodes tagged 'dataproc-node'. If you intend to use dataproc, you will need this. | `bool` | `true` | no |
+| <a name="input_create_default_buckets"></a> [create\_default\_buckets](#input\_create\_default\_buckets) | Specifies whether to create default general-use and tmp with 4-day auto-delete lifecycle buckets. | `bool` | `true` | no |
+| <a name="input_default_resource_region"></a> [default\_resource\_region](#input\_default\_resource\_region) | For managed items that require a region/location | `string` | `"us-central1"` | no |
+| <a name="input_enable_default_services"></a> [enable\_default\_services](#input\_enable\_default\_services) | Whether or not to enable the default cloudfunction or dataproc services. Set to false if you don't want to enable these, or if you want to manage them via apis\_to\_enable. | `bool` | `true` | no |
+| <a name="input_gcp_folder_id"></a> [gcp\_folder\_id](#input\_gcp\_folder\_id) | The ID numder of the GCP Organization folder to place the project in. | `string` | n/a | yes |
+| <a name="input_hail_batch_service_account"></a> [hail\_batch\_service\_account](#input\_hail\_batch\_service\_account) | The email address of a Hail Batch service account, to be granted storage and docker registry access. | `string` | `""` | no |
+| <a name="input_owner_group_id"></a> [owner\_group\_id](#input\_owner\_group\_id) | The email address for the group you would like to grant Owner access on the project. | `string` | n/a | yes |
+| <a name="input_primary_user_principal"></a> [primary\_user\_principal](#input\_primary\_user\_principal) | The primary user/group of the GCP project. This grants Editor access, and other permissions generally required to use services. Provide a IAM principal style {group/user/serviceAccount}:{email} string. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The string that should be used to create the unique ID google project; Will be suffixed with a random identifier. | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The human readable name of the project. Does not need to be unique. | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                                                                                         | Description |
-| -------------------------------------------------------------------------------------------- | ----------- |
-| <a name="output_project_identifier"></a> [project\_identifier](#output\_project\_identifier) | n/a         |
+| Name | Description |
+|------|-------------|
+| <a name="output_project_identifier"></a> [project\_identifier](#output\_project\_identifier) | n/a |
 <!-- END_TF_DOCS -->

--- a/gnomad-google-project/api_services.tf
+++ b/gnomad-google-project/api_services.tf
@@ -22,7 +22,8 @@ module "default-project-services" {
   activate_apis = [
     "dataproc.googleapis.com",
     "cloudfunctions.googleapis.com",
-    "compute.googleapis.com"
+    "compute.googleapis.com",
+    "artifactregistry.googleapis.com"
   ]
 
   disable_dependent_services  = false

--- a/gnomad-google-project/project.tf
+++ b/gnomad-google-project/project.tf
@@ -75,6 +75,12 @@ resource "google_project_iam_member" "primary_iap_tunnel_access" {
   member  = var.primary_user_principal
 }
 
+resource "google_project_iam_member" "primary_user_artifact_reg_admin" {
+  project = google_project.current_project.project_id
+  role    = "roles/artifactregistry.admin"
+  member  = var.primary_user_principal
+}
+
 # If one is provided, grant storage read/write and artifact registry read access to a hail batch service account
 resource "google_project_iam_member" "hail_batch_object_admin" {
   count   = length(var.hail_batch_service_account) > 0 ? 1 : 0

--- a/gnomad-google-project/project.tf
+++ b/gnomad-google-project/project.tf
@@ -95,6 +95,13 @@ resource "google_project_iam_member" "hail_batch_object_admin" {
   member  = "serviceAccount:${var.hail_batch_service_account}"
 }
 
+resource "google_project_iam_member" "hail_batch_object_admin" {
+  count   = length(var.hail_batch_service_account) > 0 ? 1 : 0
+  project = google_project.current_project.project_id
+  role    = "roles/storage.legacyBucketWriter"
+  member  = "serviceAccount:${var.hail_batch_service_account}"
+}
+
 resource "google_project_iam_member" "hail_batch_bucket_list" {
   count   = length(var.hail_batch_service_account) > 0 ? 1 : 0
   project = google_project.current_project.project_id

--- a/gnomad-google-project/project.tf
+++ b/gnomad-google-project/project.tf
@@ -41,6 +41,12 @@ resource "google_project_iam_member" "default_compute_service_usage" {
   member  = "serviceAccount:${google_project.current_project.number}-compute@developer.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "default_compute_artifact_read" {
+  project = google_project.current_project.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_project.current_project.number}-compute@developer.gserviceaccount.com"
+}
+
 resource "google_project_iam_custom_role" "bucket_list_role" {
   project     = google_project.current_project.project_id
   role_id     = "gnomADProjBucketList"

--- a/gnomad-google-project/variables.tf
+++ b/gnomad-google-project/variables.tf
@@ -69,3 +69,9 @@ variable "create_default_buckets" {
   description = "Specifies whether to create default general-use and tmp with 4-day auto-delete lifecycle buckets."
   default     = true
 }
+
+variable "hail_batch_service_account" {
+  type        = string
+  description = "The email address of a Hail Batch service account, to be granted storage and docker registry access."
+  default     = ""
+}


### PR DESCRIPTION
This makes a few modifications to user/collaboration sandbox projects, as discussed a few weeks ago. If a user has a hail batch account, this grants read access to the artifact registry repos in that projects to it. I've also set the primary user of the project as an artifact registry admin, which will allow them to modify permissions on docker repositories, to hopefully prevent folks getting blocked like Qin did last week.