### PR TITLE
Adds modules for an atlantis deployment

### DIFF
--- a/private-gke-cluster/README.md
+++ b/private-gke-cluster/README.md
@@ -1,0 +1,1 @@
+# Provide a GKE cluster with private networking

--- a/private-gke-cluster/README.md
+++ b/private-gke-cluster/README.md
@@ -1,1 +1,61 @@
 # Provide a GKE cluster with private networking
+
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.57.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.57.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster) | resource |
+| [google_container_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool) | resource |
+| [google_project_iam_member.gke_nodes_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.gke_nodes](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_storage_bucket_object_content.internal_networks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_bucket_object_content) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_gke_cluster_name"></a> [gke\_cluster\_name](#input\_gke\_cluster\_name) | The name of the GKE cluster you want to manage | `string` | n/a | yes |
+| <a name="input_gke_control_plane_zone"></a> [gke\_control\_plane\_zone](#input\_gke\_control\_plane\_zone) | The zone to launch the GKE cluster in | `string` | `"us-central1-c"` | no |
+| <a name="input_gke_master_ipv4_cidr_block"></a> [gke\_master\_ipv4\_cidr\_block](#input\_gke\_master\_ipv4\_cidr\_block) | The IPv4 CIDR Range (RFC1918) that should be used for the control plane | `string` | `"172.16.0.0/28"` | no |
+| <a name="input_gke_pods_range_name"></a> [gke\_pods\_range\_name](#input\_gke\_pods\_range\_name) | The name of the secondary subnet range to use for gke pods | `string` | `"gke-pods"` | no |
+| <a name="input_gke_services_range_name"></a> [gke\_services\_range\_name](#input\_gke\_services\_range\_name) | The name of the secondary subnet range to use for gke services | `string` | `"gke-services"` | no |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | A list of node pools and their configuration that should be created within the GKE cluster; pools with an empty string for the zone will deploy in the same region as the control plane | <pre>list(object({<br>    pool_name            = string<br>    pool_num_nodes       = number<br>    pool_machine_type    = string<br>    pool_preemptible     = bool<br>    pool_zone            = string<br>    pool_resource_labels = map(string)<br>  }))</pre> | <pre>[<br>  {<br>    "pool_machine_type": "e2-medium",<br>    "pool_name": "main-pool",<br>    "pool_num_nodes": 2,<br>    "pool_preemptible": true,<br>    "pool_resource_labels": {},<br>    "pool_zone": ""<br>  }<br>]</pre> | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The name of the gcp project the cluster is launching in | `string` | n/a | yes |
+| <a name="input_release_channel"></a> [release\_channel](#input\_release\_channel) | The release channel name for the GKE cluster | `string` | `"STABLE"` | no |
+| <a name="input_resource_labels"></a> [resource\_labels](#input\_resource\_labels) | A map of string values to use as resource labels on all cluster objects. | `map(string)` | `{}` | no |
+| <a name="input_vpc_network_name"></a> [vpc\_network\_name](#input\_vpc\_network\_name) | The name of the VPC network to launch the cluster in | `string` | `"default"` | no |
+| <a name="input_vpc_subnet_name"></a> [vpc\_subnet\_name](#input\_vpc\_subnet\_name) | The name of the VPC network subnet to launch the cluster in | `string` | `"default"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->
+
+## Misc
+
+### Updating this README
+
+The terraform documentation in this readme is generated with [terraform-docs](https://terraform-docs.io/). If you have modified the terraform code in a wa>
+
+```bash
+terraform-docs markdown table --output-file README.md --output-mode inject .
+```

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -11,7 +11,8 @@ resource "google_project_iam_member" "gke_nodes_iam" {
     "monitoring.metricWriter",
     "monitoring.viewer",
     "stackdriver.resourceMetadata.writer",
-    "storage.objectViewer"
+    "storage.objectViewer",
+    "artifactregistry.reader"
   ])
 
   role    = "roles/${each.key}"

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -1,0 +1,105 @@
+# Service account for GKE
+resource "google_service_account" "gke_nodes" {
+  account_id   = "${var.gke_cluster_name}-gke"
+  display_name = "${var.gke_cluster_name} GKE Nodes"
+}
+
+# IAM role for GKE
+resource "google_project_iam_member" "gke_nodes_iam" {
+  for_each = toset([
+    "logging.logWriter",
+    "monitoring.metricWriter",
+    "monitoring.viewer",
+    "stackdriver.resourceMetadata.writer",
+    "storage.objectViewer"
+  ])
+
+  role    = "roles/${each.key}"
+  member  = google_service_account.gke_nodes.member
+  project = var.project_name
+}
+
+# firewall for atlantis?
+# Static IP for Atlantis / Ingress
+# GKE Cluster
+# A document containing the Broad's public IP subnets for allowing Office and VPN IPs in firewalls
+data "google_storage_bucket_object_content" "internal_networks" {
+  name   = "internal_networks.json"
+  bucket = "broad-institute-networking"
+}
+
+resource "google_container_cluster" "gke_cluster" {
+  name            = var.gke_cluster_name
+  network         = var.vpc_network_name
+  subnetwork      = var.vpc_subnet_name
+  networking_mode = "VPC_NATIVE"
+  resource_labels = var.resource_labels
+
+  master_authorized_networks_config {
+
+    dynamic "cidr_blocks" {
+      for_each = jsondecode(data.google_storage_bucket_object_content.internal_networks.content)
+      content {
+        cidr_block = cidr_blocks.key
+      }
+    }
+  }
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = var.gke_pods_range_name
+    services_secondary_range_name = var.gke_services_range_name
+  }
+
+  # The google API won't allow creating clusters without node pools, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  workload_identity_config {
+    workload_pool = "${var.project_name}.svc.id.goog"
+  }
+
+  private_cluster_config {
+    enable_private_nodes    = true
+    master_ipv4_cidr_block  = var.gke_master_ipv4_cidr_block
+    enable_private_endpoint = false
+  }
+
+  release_channel {
+    channel = "STABLE"
+  }
+
+  maintenance_policy {
+    recurring_window {
+      start_time = "1970-01-01T07:00:00Z"
+      end_time   = "1970-01-01T11:00:00Z"
+      recurrence = "FREQ=DAILY"
+    }
+  }
+}
+
+resource "google_container_node_pool" "node_pool" {
+  for_each   = { for pool in var.node_pools : pool.pool_name => pool }
+  name       = each.value.pool_name
+  location   = each.value.pool_zone != "" ? each.value.pool_zone : var.gke_control_plane_zone
+  cluster    = google_container_cluster.gke_cluster.name
+  node_count = each.value.pool_num_nodes
+
+  node_config {
+    machine_type    = each.value.pool_machine_type
+    preemptible     = each.value.pool_preemptible
+    service_account = google_service_account.gke_cluster_sa.email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    tags = ["${var.gke_cluster_name}", "${var.gke_cluster_name}-${each.value.pool_name}"]
+
+    resource_labels = each.value.pool_resource_labels
+  }
+}

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -38,7 +38,7 @@ resource "google_container_cluster" "gke_cluster" {
   master_authorized_networks_config {
 
     dynamic "cidr_blocks" {
-      for_each = jsondecode(data.google_storage_bucket_object_content.internal_networks.content)
+      for_each = toset(jsondecode(data.google_storage_bucket_object_content.internal_networks.content))
       content {
         cidr_block = cidr_blocks.key
       }

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -89,7 +89,7 @@ resource "google_container_node_pool" "node_pool" {
   node_config {
     machine_type    = each.value.pool_machine_type
     preemptible     = each.value.pool_preemptible
-    service_account = google_service_account.gke_cluster_sa.email
+    service_account = google_service_account.gke_nodes.email
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform"
     ]

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -33,6 +33,7 @@ resource "google_container_cluster" "gke_cluster" {
   network         = var.vpc_network_name
   subnetwork      = var.vpc_subnet_name
   networking_mode = "VPC_NATIVE"
+  location        = var.gke_control_plane_zone
   resource_labels = var.resource_labels
 
   master_authorized_networks_config {

--- a/private-gke-cluster/outputs.tf
+++ b/private-gke-cluster/outputs.tf
@@ -1,0 +1,2 @@
+# service account email
+# cluster name

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -8,6 +8,12 @@ variable "project_name" {
   type        = string
 }
 
+variable "gke_control_plane_zone" {
+  description = "The zone to launch the GKE cluster in"
+  type        = string
+  default     = "us-central1-c"
+}
+
 variable "gke_master_ipv4_cidr_block" {
   description = "The IPv4 CIDR Range (RFC1918) that should be used for the control plane"
   type        = string

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -1,0 +1,73 @@
+variable "gke_cluster_name" {
+  description = "The name of the GKE cluster you want to manage"
+  type        = string
+}
+
+variable "project_name" {
+  description = "The name of the gcp project the cluster is launching in"
+  type        = string
+}
+
+variable "gke_master_ipv4_cidr_block" {
+  description = "The IPv4 CIDR Range (RFC1918) that should be used for the control plane"
+  type        = string
+  default     = "172.16.0.0/28"
+}
+
+variable "gke_services_range_name" {
+  description = "The name of the secondary subnet range to use for gke services"
+  type        = string
+  default     = "gke-services"
+}
+
+variable "gke_pods_range_name" {
+  description = "The name of the secondary subnet range to use for gke pods"
+  type        = string
+  default     = "gke-pods"
+}
+
+variable "resource_labels" {
+  description = "A map of string values to use as resource labels on all cluster objects."
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_network_name" {
+  description = "The name of the VPC network to launch the cluster in"
+  type        = string
+  default     = "default"
+}
+
+variable "vpc_subnet_name" {
+  description = "The name of the VPC network subnet to launch the cluster in"
+  type        = string
+  default     = "default"
+}
+
+variable "release_channel" {
+  description = "The release channel name for the GKE cluster"
+  type        = string
+  default     = "STABLE"
+}
+
+variable "node_pools" {
+  description = "A list of node pools and their configuration that should be created within the GKE cluster; pools with an empty string for the zone will deploy in the same region as the control plane"
+  type = list(object({
+    pool_name            = string
+    pool_num_nodes       = number
+    pool_machine_type    = string
+    pool_preemptible     = bool
+    pool_zone            = string
+    pool_resource_labels = map(string)
+  }))
+  default = [
+    {
+      "pool_name"            = "main-pool"
+      "pool_num_nodes"       = 2
+      "pool_machine_type"    = "e2-standard-4"
+      "pool_preemptible"     = true
+      "pool_zone"            = ""
+      "pool_resource_labels" = {}
+    }
+  ]
+}

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -70,7 +70,7 @@ variable "node_pools" {
     {
       "pool_name"            = "main-pool"
       "pool_num_nodes"       = 2
-      "pool_machine_type"    = "e2-standard-4"
+      "pool_machine_type"    = "e2-medium"
       "pool_preemptible"     = true
       "pool_zone"            = ""
       "pool_resource_labels" = {}

--- a/private-gke-cluster/versions.tf
+++ b/private-gke-cluster/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.57.0"
+    }
+  }
+}

--- a/tgg-atlantis/README.md
+++ b/tgg-atlantis/README.md
@@ -1,0 +1,59 @@
+# tgg-atlantis
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 5.18.3 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.57.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_github"></a> [github](#provider\_github) | >= 5.18.3 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.57.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_atlantis-gke"></a> [atlantis-gke](#module\_atlantis-gke) | github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster | bc1853e79f848c52ae014cf0210f78fa9fc8481c |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_global_address.atlantis_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_security_policy.argocd_cloudarmor_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_security_policy) | resource |
+| [google_compute_security_policy.atlantis_cloudarmor_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_security_policy) | resource |
+| [google_service_account.atlantis_runner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_member.atlantis_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [github_ip_ranges.github_hook_ips](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/ip_ranges) | data source |
+| [google_storage_bucket_object_content.broad_networks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_bucket_object_content) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_vpc_network_name"></a> [vpc\_network\_name](#input\_vpc\_network\_name) | The name of the VPC network to deploy atlantis in | `string` | `"atlantis"` | no |
+| <a name="input_vpc_subnet_name"></a> [vpc\_subnet\_name](#input\_vpc\_subnet\_name) | The name of the VPC network subnet to deploy atlantis in | `string` | `"atlantis"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_tgg_atlantis_ip"></a> [tgg\_atlantis\_ip](#output\_tgg\_atlantis\_ip) | n/a |
+<!-- END_TF_DOCS -->
+
+## Misc
+
+### Updating this README
+
+The terraform documentation in this readme is generated with [terraform-docs](https://terraform-docs.io/). If you have modified the terraform code in a wa>
+
+```bash
+terraform-docs markdown table --output-file README.md --output-mode inject .
+```

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -78,7 +78,7 @@ resource "google_compute_security_policy" "atlantis_cloudarmor_policy" {
 }
 
 # Cloudarmor policy for restricting argocd UI access to Broad networks
-data "google_storage_buckte_object_content" "broad_networks" {
+data "google_storage_bucket_object_content" "broad_networks" {
   name   = "internal_networks.json"
   bucket = "broad-institute-networking"
 }

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -21,5 +21,5 @@ resource "google_service_account" "atlantis_runner" {
 
 # static IP, tls cert etc
 resource "google_compute_global_address" "atlantis_ip" {
-  name = "TGG Atlantis"
+  name = "tgg-atlantis"
 }

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -1,7 +1,7 @@
 # include GKE cluster
 
 module "atlantis-gke" {
-  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=4e2943c925ac00c95d247a5502356d616add83e4"
+  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=877b3a5117e12053005fd7e8f9f943e6efde5f17"
   gke_cluster_name = "tgg-atlantis"
   project_name     = "tgg-automation"
   resource_labels = {

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -1,7 +1,7 @@
 # include GKE cluster
 
 module "atlantis-gke" {
-  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=private-gke-cluster-v0.0.1"
+  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=a9eea7c9f2e5059d478a52f4d658909365943373"
   gke_cluster_name = "tgg-atlantis"
   project_name     = "tgg-automation"
   resource_labels = {

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -115,4 +115,3 @@ resource "google_compute_security_policy" "argocd_cloudarmor_policy" {
     }
   }
 }
-#  

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -1,7 +1,7 @@
 # include GKE cluster
 
 module "atlantis-gke" {
-  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=a9eea7c9f2e5059d478a52f4d658909365943373"
+  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=c54aabc767cb87d49c7862f633940314d952445f"
   gke_cluster_name = "tgg-atlantis"
   project_name     = "tgg-automation"
   resource_labels = {

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -1,7 +1,7 @@
 # include GKE cluster
 
 module "atlantis-gke" {
-  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=877b3a5117e12053005fd7e8f9f943e6efde5f17"
+  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=bc1853e79f848c52ae014cf0210f78fa9fc8481c"
   gke_cluster_name = "tgg-atlantis"
   project_name     = "tgg-automation"
   resource_labels = {

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -1,7 +1,7 @@
 # include GKE cluster
 
 module "atlantis-gke" {
-  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=d1f96ee484ffdc3f85461d8613c04054aca7ddbc"
+  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=4e2943c925ac00c95d247a5502356d616add83e4"
   gke_cluster_name = "tgg-atlantis"
   project_name     = "tgg-automation"
   resource_labels = {

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -1,7 +1,7 @@
 # include GKE cluster
 
 module "atlantis-gke" {
-  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=c54aabc767cb87d49c7862f633940314d952445f"
+  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=74237dbf5fa02ef045ca920f5907453477e2054a"
   gke_cluster_name = "tgg-atlantis"
   project_name     = "tgg-automation"
   resource_labels = {

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -9,6 +9,16 @@ module "atlantis-gke" {
     "deployment" = "atlantis"
     "component"  = "gke"
   }
+  node_pools = [
+    {
+      "pool_name"            = "main-pool"
+      "pool_num_nodes"       = 2
+      "pool_machine_type"    = "e2-standard-2"
+      "pool_preemptible"     = true
+      "pool_zone"            = ""
+      "pool_resource_labels" = {}
+    }
+  ]
   vpc_network_name = var.vpc_network_name
   vpc_subnet_name  = var.vpc_subnet_name
 }

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -12,7 +12,7 @@ module "atlantis-gke" {
   node_pools = [
     {
       "pool_name"            = "main-pool"
-      "pool_num_nodes"       = 2
+      "pool_num_nodes"       = 3
       "pool_machine_type"    = "e2-standard-2"
       "pool_preemptible"     = true
       "pool_zone"            = ""

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -1,7 +1,7 @@
 # include GKE cluster
 
 module "atlantis-gke" {
-  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=74237dbf5fa02ef045ca920f5907453477e2054a"
+  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=d1f96ee484ffdc3f85461d8613c04054aca7ddbc"
   gke_cluster_name = "tgg-atlantis"
   project_name     = "tgg-automation"
   resource_labels = {

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -19,6 +19,12 @@ resource "google_service_account" "atlantis_runner" {
   display_name = "TGG Atlantis Runner"
 }
 
+resource "google_service_account_iam_member" "es_snapshots" {
+  role               = "roles/iam.workloadIdentityUser"
+  service_account_id = google_service_account.atlantis_runner.name
+  member             = "serviceAccount:tgg-automation.svc.id.goog[atlantis/atlantis]"
+}
+
 # static IP, tls cert etc
 resource "google_compute_global_address" "atlantis_ip" {
   name = "tgg-atlantis"

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -19,7 +19,7 @@ resource "google_service_account" "atlantis_runner" {
   display_name = "TGG Atlantis Runner"
 }
 
-resource "google_service_account_iam_member" "es_snapshots" {
+resource "google_service_account_iam_member" "atlantis_identity" {
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.atlantis_runner.name
   member             = "serviceAccount:tgg-automation.svc.id.goog[atlantis/atlantis]"

--- a/tgg-atlantis/main.tf
+++ b/tgg-atlantis/main.tf
@@ -1,0 +1,25 @@
+# include GKE cluster
+
+module "atlantis-gke" {
+  source           = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=private-gke-cluster-v0.0.1"
+  gke_cluster_name = "tgg-atlantis"
+  project_name     = "tgg-automation"
+  resource_labels = {
+    "terraform"  = "true"
+    "deployment" = "atlantis"
+    "component"  = "gke"
+  }
+  vpc_network_name = var.vpc_network_name
+  vpc_subnet_name  = var.vpc_subnet_name
+}
+
+# atlantis service account
+resource "google_service_account" "atlantis_runner" {
+  account_id   = "tgg-atlantis-runner"
+  display_name = "TGG Atlantis Runner"
+}
+
+# static IP, tls cert etc
+resource "google_compute_global_address" "atlantis_ip" {
+  name = "TGG Atlantis"
+}

--- a/tgg-atlantis/outputs.tf
+++ b/tgg-atlantis/outputs.tf
@@ -1,0 +1,3 @@
+output "tgg_atlantis_ip" {
+  value = google_compute_global_address.atlantis_ip.address
+}

--- a/tgg-atlantis/variables.tf
+++ b/tgg-atlantis/variables.tf
@@ -1,0 +1,11 @@
+variable "vpc_network_name" {
+  description = "The name of the VPC network to deploy atlantis in"
+  type        = string
+  default     = "atlantis"
+}
+
+variable "vpc_subnet_name" {
+  description = "The name of the VPC network subnet to deploy atlantis in"
+  type        = string
+  default     = "atlantis"
+}

--- a/tgg-atlantis/versions.tf
+++ b/tgg-atlantis/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 4.57.0"
     }
+    github = {
+      source  = "integrations/github"
+      version = ">= 5.18.3"
+    }
   }
 }

--- a/tgg-atlantis/versions.tf
+++ b/tgg-atlantis/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.57.0"
+    }
+  }
+}

--- a/vpc-with-nat-subnet/README.md
+++ b/vpc-with-nat-subnet/README.md
@@ -2,4 +2,53 @@
 
 The intention of this module is to configure a subnet with a NAT gateway, which is suitable for running GCE instances that aren't on the public internet. This is a pattern that I imagine I'm going to need elsewhere, so I figured it was best to abstract it out, rather than using the gnomad-specific network config in the gnomad-vpc module.
 
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_network.network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
+| [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
+| [google_compute_router_nat.router_nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
+| [google_compute_subnetwork.subnet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
+
 ## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_enable_google_private_access"></a> [enable\_google\_private\_access](#input\_enable\_google\_private\_access) | Whether to enable private network access for google services in the primary subnet | `bool` | `true` | no |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name that should be given to the VPC network | `string` | `"atlantis"` | no |
+| <a name="input_primary_subnet_cidr"></a> [primary\_subnet\_cidr](#input\_primary\_subnet\_cidr) | The RFC1918 CIDR mask for the primary subnet range | `string` | `"192.168.0.0/20"` | no |
+| <a name="input_secondary_network_ranges"></a> [secondary\_network\_ranges](#input\_secondary\_network\_ranges) | A list of network range objects | <pre>list(object({<br>    range_name    = string<br>    ip_cidr_range = string<br>  }))</pre> | <pre>[<br>  {<br>    "ip_cidr_range": "10.0.32.0/20",<br>    "range_name": "gke-services"<br>  },<br>  {<br>    "ip_cidr_range": "10.4.0.0/14",<br>    "range_name": "gke-pods"<br>  }<br>]</pre> | no |
+| <a name="input_subnet_name_suffix"></a> [subnet\_name\_suffix](#input\_subnet\_name\_suffix) | The suffix for the name of the primary subnet; resulting name is network\_name-subnet\_name\_suffix | `string` | `"gke"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_vpc_network_name"></a> [vpc\_network\_name](#output\_vpc\_network\_name) | n/a |
+| <a name="output_vpc_subnet_name"></a> [vpc\_subnet\_name](#output\_vpc\_subnet\_name) | n/a |
+<!-- END_TF_DOCS -->
+
+## Misc
+
+### Updating this README
+
+The terraform documentation in this readme is generated with [terraform-docs](https://terraform-docs.io/). If you have modified the terraform code in a wa>
+
+```bash
+terraform-docs markdown table --output-file README.md --output-mode inject .

--- a/vpc-with-nat-subnet/README.md
+++ b/vpc-with-nat-subnet/README.md
@@ -1,0 +1,5 @@
+# SSH Firewall Rules
+
+The intention of this module is to configure a subnet with a NAT gateway, which is suitable for running GCE instances that aren't on the public internet. This is a pattern that I imagine I'm going to need elsewhere, so I figured it was best to abstract it out, rather than using the gnomad-specific network config in the gnomad-vpc module.
+
+## Inputs

--- a/vpc-with-nat-subnet/README.md
+++ b/vpc-with-nat-subnet/README.md
@@ -1,4 +1,4 @@
-# SSH Firewall Rules
+# VPC with NATed subnet
 
 The intention of this module is to configure a subnet with a NAT gateway, which is suitable for running GCE instances that aren't on the public internet. This is a pattern that I imagine I'm going to need elsewhere, so I figured it was best to abstract it out, rather than using the gnomad-specific network config in the gnomad-vpc module.
 

--- a/vpc-with-nat-subnet/main.tf
+++ b/vpc-with-nat-subnet/main.tf
@@ -1,0 +1,41 @@
+resource "google_compute_network" "network" {
+  name                    = var.network_name
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${var.network_name}-${var.subnet_name}"
+  ip_cidr_range = var.primary_subnet_cidr # "192.168.0.0/20"
+  network       = google_compute_network.network.name
+
+  secondary_ip_range = var.secondary_ranges
+
+
+
+  private_ip_google_access = var.enable_google_private_access
+
+  log_config {
+    aggregation_interval = "INTERVAL_5_SEC"
+    flow_sampling        = 0.5
+    metadata             = "EXCLUDE_ALL_METADATA"
+  }
+}
+
+resource "google_compute_router" "router" {
+  name    = "${var.network_name_prefix}-nat"
+  network = google_compute_network.network.id
+}
+
+
+resource "google_compute_router_nat" "router_nat" {
+  name                               = "${var.network_name_prefix}-router-nat"
+  router                             = google_compute_router.router.name
+  region                             = google_compute_router.router.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}

--- a/vpc-with-nat-subnet/main.tf
+++ b/vpc-with-nat-subnet/main.tf
@@ -8,7 +8,7 @@ resource "google_compute_subnetwork" "subnet" {
   ip_cidr_range = var.primary_subnet_cidr
   network       = google_compute_network.network.name
 
-  secondary_ip_range = var.secondary_ranges
+  secondary_ip_range = var.secondary_network_ranges
 
 
 

--- a/vpc-with-nat-subnet/main.tf
+++ b/vpc-with-nat-subnet/main.tf
@@ -4,8 +4,8 @@ resource "google_compute_network" "network" {
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  name          = "${var.network_name}-${var.subnet_name}"
-  ip_cidr_range = var.primary_subnet_cidr # "192.168.0.0/20"
+  name          = "${var.network_name}-${var.subnet_name_suffix}"
+  ip_cidr_range = var.primary_subnet_cidr
   network       = google_compute_network.network.name
 
   secondary_ip_range = var.secondary_ranges

--- a/vpc-with-nat-subnet/main.tf
+++ b/vpc-with-nat-subnet/main.tf
@@ -22,13 +22,13 @@ resource "google_compute_subnetwork" "subnet" {
 }
 
 resource "google_compute_router" "router" {
-  name    = "${var.network_name_prefix}-nat"
+  name    = "${var.network_name}-nat"
   network = google_compute_network.network.id
 }
 
 
 resource "google_compute_router_nat" "router_nat" {
-  name                               = "${var.network_name_prefix}-router-nat"
+  name                               = "${var.network_name}-router-nat"
   router                             = google_compute_router.router.name
   region                             = google_compute_router.router.region
   nat_ip_allocate_option             = "AUTO_ONLY"

--- a/vpc-with-nat-subnet/outputs.tf
+++ b/vpc-with-nat-subnet/outputs.tf
@@ -1,0 +1,7 @@
+output "vpc_network_name" {
+  value = google_compute_network.network.name
+}
+
+output "vpc_subnet_name" {
+  value = google_compute_subnetwork.subnet.name
+}

--- a/vpc-with-nat-subnet/variables.tf
+++ b/vpc-with-nat-subnet/variables.tf
@@ -18,7 +18,10 @@ variable "primary_subnet_cidr" {
 
 variable "secondary_network_ranges" {
   description = "A list of network range objects"
-  type        = list(object)
+  type = list(object({
+    range_name    = string
+    ip_cidr_range = string
+  }))
   default = [
     {
       range_name    = "gke-services"

--- a/vpc-with-nat-subnet/variables.tf
+++ b/vpc-with-nat-subnet/variables.tf
@@ -4,10 +4,16 @@ variable "network_name" {
   default     = "atlantis"
 }
 
-variable "subnet_name" {
-  description = "The name of the primary subnet"
+variable "subnet_name_suffix" {
+  description = "The suffix for the name of the primary subnet; resulting name is network_name-subnet_name_suffix"
   type        = string
   default     = "gke"
+}
+
+variable "primary_subnet_cidr" {
+  description = "The RFC1918 CIDR mask for the primary subnet range"
+  type        = string
+  default     = "192.168.0.0/20"
 }
 
 variable "secondary_network_ranges" {

--- a/vpc-with-nat-subnet/variables.tf
+++ b/vpc-with-nat-subnet/variables.tf
@@ -1,0 +1,32 @@
+variable "network_name" {
+  description = "The name that should be given to the VPC network"
+  type        = string
+  default     = "atlantis"
+}
+
+variable "subnet_name" {
+  description = "The name of the primary subnet"
+  type        = string
+  default     = "gke"
+}
+
+variable "secondary_network_ranges" {
+  description = "A list of network range objects"
+  type        = list(object)
+  default = [
+    {
+      range_name    = "gke-services"
+      ip_cidr_range = "10.0.32.0/20"
+    },
+    {
+      range_name    = "gke-pods"
+      ip_cidr_range = "10.4.0.0/14"
+    }
+  ]
+}
+
+variable "enable_google_private_access" {
+  description = "Whether to enable private network access for google services in the primary subnet"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
I've written generic modules for deploying a few primitives (a VPC with a NAT gateway and single subnet, a private GKE cluster) that I'm finding myself using all the time, and then composed them into a module for deploying [](https://runatlantis.io)

Depending on how well this works, I may refactor the gnomad infra module to use these primitive modules as well.