### PR TITLE
make local ssds configurable in seqr nodepool

### DIFF
--- a/seqr-gke-nodepool/main.tf
+++ b/seqr-gke-nodepool/main.tf
@@ -16,7 +16,7 @@ resource "google_container_node_pool" "node_pool" {
 
     labels = var.node_pool_labels
 
-    local_ssd_count = "0"
+    local_ssd_count = var.node_pool_local_ssd_count
     machine_type    = var.node_pool_machine_type
 
     metadata = {

--- a/seqr-gke-nodepool/variables.tf
+++ b/seqr-gke-nodepool/variables.tf
@@ -34,3 +34,8 @@ variable "node_pool_image_type" {
   description = "The GKE image to use for the node pool. Should usually be COS_CONTAINERD."
   default     = "COS_CONTAINERD"
 }
+
+variable "node_pool_local_ssd_count" {
+  type    = string
+  default = "0"
+}


### PR DESCRIPTION
The need arose to add a local SSD to seqr's node pool config, this makes that a variable