### PR TITLE
Add hooks for min/max instances

### DIFF
--- a/scheduled-cloudfunction/main.tf
+++ b/scheduled-cloudfunction/main.tf
@@ -9,6 +9,8 @@ resource "google_cloudfunctions_function" "scheduled-cloudfunction" {
   ingress_settings      = "ALLOW_INTERNAL_ONLY"
   service_account_email = var.service_account_email
   timeout               = var.function_timeout
+  min_instances         = var.min_instances
+  max_instances         = var.max_instances
   labels = {
     managed-by = "terraform"
   }

--- a/scheduled-cloudfunction/variables.tf
+++ b/scheduled-cloudfunction/variables.tf
@@ -66,3 +66,15 @@ variable "function_timeout" {
     error_message = "The function_timeout must be greater than or equal to 10, and less than or equal to 540."
   }
 }
+
+variable "min_instances" {
+  type        = number
+  default     = 0
+  description = "The minimum number of function instances that should be running. Set to non-zero to ensure always-available capacity."
+}
+
+variable "max_instances" {
+  type        = number
+  default     = 3000
+  description = "The maximum number of function instance that should be allowed to run. Google default is 3000."
+}


### PR DESCRIPTION
Adds variables for allowing module users to define min/max instances in scheduled cloudfunctions.