### PR TITLE
Allow pod / service IP network ranges to be specified for gnomad-browser deployments

### DIFF
--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -115,6 +115,8 @@ module "gnomad-gke" {
   gke_control_plane_authorized_networks = toset(var.gke_control_plane_authorized_networks)
   gke_recurring_maint_windows           = var.gke_recurring_maint_windows
   gke_maint_exclusions                  = var.gke_maint_exclusions
+  gke_pods_range_slice                  = var.gke_pods_range_slice
+  gke_services_range_slice              = var.gke_services_range_slice
 }
 
 resource "google_compute_firewall" "es_webbook" {

--- a/gnomad-browser-infra/outputs.tf
+++ b/gnomad-browser-infra/outputs.tf
@@ -5,3 +5,8 @@ output "public_web_address" {
 output "gke_cluster_name" {
   value = module.gnomad-gke.gke_cluster_name
 }
+
+# for obtaining the internal network value that should be set in gnomad's PROXY_IPS env variable
+output "gke_pods_ipv4_cidr_block" {
+  value = module.gnomad-gke.gke_pods_ipv4_cidr_block
+}

--- a/gnomad-browser-infra/variables.tf
+++ b/gnomad-browser-infra/variables.tf
@@ -30,6 +30,18 @@ variable "gke_control_plane_authorized_networks" {
   default     = []
 }
 
+variable "gke_services_range_slice" {
+  description = "The full (e.g. 10.0.0.0/20) or simple (e.g. /20) CIDR range slice to assign for internal service IP addresses"
+  type        = string
+  default     = "/20"
+}
+
+variable "gke_pods_range_slice" {
+  description = "The full (e.g. 10.0.0.0/14) or simple (e.g. /14) CIDR range slice to assign for internal pod IP addresses"
+  type        = string
+  default     = "/14"
+}
+
 # see https://cloud.google.com/kubernetes-engine/docs/how-to/maintenance-windows-and-exclusions#maintenance-window
 # for more information regarding timestamp formatting and recurrence spec syntax
 variable "gke_recurring_maint_windows" {

--- a/private-gke-cluster/outputs.tf
+++ b/private-gke-cluster/outputs.tf
@@ -12,3 +12,8 @@ output "gke_cluster_name" {
 output "gke_control_plane_cidr" {
   value = google_container_cluster.gke_cluster.private_cluster_config[0].master_ipv4_cidr_block
 }
+
+# ipv4 cidr block for pods running in the cluster
+output "gke_pods_ipv4_cidr_block" {
+  value = google_container_cluster.gke_cluster.ip_allocation_policy[0].cluster_ipv4_cidr_block
+}


### PR DESCRIPTION
This change allows users of the gnomad-browser-infra module to pass the pods and services IP ranges to the underlying private-gke-cluster module (which already allows specifying these). We were previously relying on the default values from private-gke-cluster, but I figured that it'd be nice to allow specifying this in case folks need to control what these ranges are for application-level things. In our case, this is helpful for controlling the ranges that go into the nginx set_real_ip_from config / PROXY_IPS env variable in the gnomad browser.

I've also added an output that prints the pods range to both private-gke-cluster and gnomad-browser-infra, so that you can be awared of what the range is at deployment time.