### PR TITLE
remove target tag from dataproc-node firewall rule

### DIFF
--- a/gnomad-vpc/main.tf
+++ b/gnomad-vpc/main.tf
@@ -22,7 +22,7 @@ module "gnomad-vpc" {
 resource "google_compute_firewall" "dataproc_internal" {
   name        = "${var.network_name_prefix}-dataproc-internal-allow"
   network     = module.gnomad-vpc.vpc_network_name
-  description = "Creates firewall rule allowing dataproc tagged instances to reach eachother"
+  description = "Creates firewall rule allowing dataproc tagged instances to reach all other hosts on the network"
 
   allow {
     protocol = "tcp"
@@ -39,7 +39,6 @@ resource "google_compute_firewall" "dataproc_internal" {
   }
 
   source_tags = ["dataproc-node"]
-  target_tags = ["dataproc-node"]
 }
 
 # allows SSH access from the Identity Aware Proxy service (for cloud-console based SSH sessions)


### PR DESCRIPTION
For reasons yet unknown to me, the firewall rule that allowed all traffic from dataproc-node tagged instances to other instances with that tag is no longer sufficient for our export_to_elasticsearch pipeline to function.

Our export_to_elasticsearch jobs started hanging unless we allowed connectivity to the es-data GKE pool. It was not required to allow traffic to the main pool, but I found that this improved performance.

Since we're not really sure what network topologies and tags people are ultimately passing into this module, i opted to just allow traffic to all hosts, rather than the tags specific to our GKE nodes. At the moment, I don't think this is a big deal, since there is nothing else in the VPC