### PR TITLE
actually pass the browser node pools variable to the GKE cluster module

### DIFF
--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -79,36 +79,7 @@ module "gnomad-gke" {
     "deployment" = "gnomad_browser"
     "component"  = "gke"
   }
-  node_pools = [
-    {
-      "pool_name"            = "main-pool"
-      "pool_num_nodes"       = 2
-      "pool_machine_type"    = "e2-standard-4"
-      "pool_preemptible"     = false
-      "pool_zone"            = ""
-      "pool_resource_labels" = {}
-    },
-    {
-      "pool_name"         = "redis"
-      "pool_num_nodes"    = 1
-      "pool_machine_type" = "e2-custom-6-49152"
-      "pool_preemptible"  = false
-      "pool_zone"         = ""
-      "pool_resource_labels" = {
-        "component" = "redis"
-      }
-    },
-    {
-      "pool_name"         = "es-data"
-      "pool_num_nodes"    = 3
-      "pool_machine_type" = "e2-highmem-8"
-      "pool_preemptible"  = false
-      "pool_zone"         = ""
-      "pool_resource_labels" = {
-        "component" = "elasticsearch"
-      }
-    }
-  ]
+  node_pools = var.gke_node_pools
 
   vpc_network_name                      = var.vpc_network_name
   vpc_subnet_name                       = var.vpc_subnet_name


### PR DESCRIPTION
I must have goofed this during the refactor, but I was not actually passing the gke_node_pools variable in gnomad-browser-infra to the private-gke-cluster module. The pools i was statically defining matched the default variable value so this should be a no-op for our production cluster. But, the result was that if you used this module and passed in a custom set of node pools, those weren't being honored.

It doesn't appear in the diff here, but the value for `var.gke_node_pools` can be found at [gnomad-browser-infra/variables.tf](https://github.com/broadinstitute/tgg-terraform-modules/blob/7db4e0b4a006c38f93d3aa4455a1990ebd97ba2a/gnomad-browser-infra/variables.tf#L66)

fixes #21 