### PR TITLE
rewrite scheduled-cloudfunction to fit our preferred deployment pattern

### DIFF
--- a/scheduled-cloudfunction/README.md
+++ b/scheduled-cloudfunction/README.md
@@ -29,11 +29,30 @@ module "my_scheduled_cloudfunction" {
 }
 ```
 
+## Service Accounts
+
+If `manage_service_accounts` is set to `true`, the module will provision two service accounts: one for the runtime of the function, and one for the deployment of the function. The runtime service account IAM roles can be provided via a list in `service_account_roles`. The module will configure the necessary permissions for the deployment service account to execute `gcloud functions deploy`. If you choose to enable workload identity federation, that will be configured with a mapping appropriate for allowing the deployment service account to be authenticated with in a GitHub Action.
+
+If you wish to use your own / pre-existing service accounts, set `manage_service_accounts` to false. In this case, you'll need to provision IAM permissions (and workload identity federation) on your own. Typically, the following permissions are needed for a function deployment:
+
+Runtime service account (the SA your function uses while executing your code):
+- Any IAM roles needed for the actions it takes (e.g. `roles/storage.objectViewer` if it needs to read GCS objects, etc)
+- `roles/secretmanager.secretAccessor` on any secrets that your function needs during runtime
+
+Deployment service account (the SA that executes `gcloud functions deploy`):
+- `roles/cloudfunctions.admin`
+- `roles/iam.serviceAccountUser` on the runtime service account
+
+In some circumstances, your GCP project's google-managed service account for Cloud Build will need:
+- `roles/iam.serviceAccountUser` on the runtime service account
+
 ## Workload Identity Federation
 
-This module configures workload identity federation with GitHub Actions, to allow the github action to authenticate for function deployment. The default set of conditions that governs what actions will be able to do things is: Only commits to `refs/heads/main` on the [gnomAD storage monitoring](https://github.com/broadinstitute/gnomad-storage-monitoring) repository will be allowed to authenticate.
+This module optionally configures workload identity federation with GitHub Actions, to allow the github action to authenticate for function deployment. The default set of conditions that governs what actions will be able to do things is: Only commits to `refs/heads/main` on the [gnomAD storage monitoring](https://github.com/broadinstitute/gnomad-storage-monitoring) repository will be allowed to authenticate.
 
 If you need to use another branch / repository, adjust the `workload_identity_attr_condition` (the assertion rule) and the `workload_identity_attr` (the target repository) accordingly.
+
+You cannot enable workload identity federation via the module if you set `manage_service_accounts` to `false`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -74,11 +93,13 @@ If you need to use another branch / repository, adjust the `workload_identity_at
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudbuild_service_account_email"></a> [cloudbuild\_service\_account\_email](#input\_cloudbuild\_service\_account\_email) | The email address of the cloudbuild service account | `string` | n/a | yes |
+| <a name="input_configure_workload_identity"></a> [configure\_workload\_identity](#input\_configure\_workload\_identity) | Whether or not to configure workload identity federation for the scheduled function and github actions. Cannot be specified if manage\_service\_accounts is false | `bool` | `true` | no |
 | <a name="input_cron_schedule"></a> [cron\_schedule](#input\_cron\_schedule) | A string representing the cron-format schedule for which to trigger the cloud function | `string` | n/a | yes |
+| <a name="input_manage_service_accounts"></a> [manage\_service\_accounts](#input\_manage\_service\_accounts) | Whether or not to manage the service accounts for the scheduled function and the deployment service account | `bool` | `true` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project id of the project in which to create the scheduled function | `string` | n/a | yes |
-| <a name="input_required_gcp_secrets"></a> [required\_gcp\_secrets](#input\_required\_gcp\_secrets) | A list of the names of GCP Secret Manager secrets that the scheudled function requires to run | `list(string)` | `[]` | no |
+| <a name="input_required_gcp_secrets"></a> [required\_gcp\_secrets](#input\_required\_gcp\_secrets) | A list of the names of GCP Secret Manager secrets that the scheudled function requires to run. Cannot be specified if manage\_service\_accounts is false | `list(string)` | `[]` | no |
 | <a name="input_scheduled_function_name"></a> [scheduled\_function\_name](#input\_scheduled\_function\_name) | The string that should be used to create resources associated with the module, svc account, pubsub queue, etc | `string` | n/a | yes |
-| <a name="input_service_account_roles"></a> [service\_account\_roles](#input\_service\_account\_roles) | A list of roles to assign to the service account created for the scheduled function | `list(string)` | <pre>[<br>  "roles/cloudfunctions.invoker"<br>]</pre> | no |
+| <a name="input_service_account_roles"></a> [service\_account\_roles](#input\_service\_account\_roles) | A list of roles to assign to the service account created for the scheduled function. Cannot be specified if manage\_service\_accounts is false | `list(string)` | `[]` | no |
 | <a name="input_workload_identity_attr"></a> [workload\_identity\_attr](#input\_workload\_identity\_attr) | value of the workload identity attribute to use for the scheduled function workload identity mapping | `string` | `"attribute.repository/broadinstitute/gnomad-storage-monitoring"` | no |
 | <a name="input_workload_identity_attr_condition"></a> [workload\_identity\_attr\_condition](#input\_workload\_identity\_attr\_condition) | The workload identity attribute condition to use for the scheduled function workload identity mapping | `string` | `"assertion.ref=='refs/heads/main'"` | no |
 

--- a/scheduled-cloudfunction/README.md
+++ b/scheduled-cloudfunction/README.md
@@ -21,6 +21,8 @@ It's recommended that you delete any pre-v1.0.0 deployments of this module, appl
 module "my_scheduled_cloudfunction" {
     source = "github.com/broadinstitute/tgg-terraform-modules//scheduled-cloudfunction?ref=v1.0.0"
     scheduled_function_name = "run-a-doodad"
+    runtime_service_account_email = "my-runtime@myproj.iam.gserviceaccount.com"
+    deployment_service_account_email = "my-deployer@myproj.iam.gserviceaccount.com"
     cloudbuild_service_account_email = "cloubuild@myproj.iam.gserviceaccount.com"
     cron_schedule = "30 7 * * 1"
     required_gcp_secrets = ["my-slack-token-gcp-secret-name", "database-password-secret-name"]
@@ -31,28 +33,17 @@ module "my_scheduled_cloudfunction" {
 
 ## Service Accounts
 
-If `manage_service_accounts` is set to `true`, the module will provision two service accounts: one for the runtime of the function, and one for the deployment of the function. The runtime service account IAM roles can be provided via a list in `service_account_roles`. The module will configure the necessary permissions for the deployment service account to execute `gcloud functions deploy`. If you choose to enable workload identity federation, that will be configured with a mapping appropriate for allowing the deployment service account to be authenticated with in a GitHub Action.
+You must provide the email addresses of three service accounts. You can create or reuse them by any means, but they are required for granting the function access to resources it needs, and setting up permissions for cloudbuild and the deployment service account to actually deploy the function:
 
-If you wish to use your own / pre-existing service accounts, set `manage_service_accounts` to false. In this case, you'll need to provision IAM permissions (and workload identity federation) on your own. Typically, the following permissions are needed for a function deployment:
-
-Runtime service account (the SA your function uses while executing your code):
-- Any IAM roles needed for the actions it takes (e.g. `roles/storage.objectViewer` if it needs to read GCS objects, etc)
-- `roles/secretmanager.secretAccessor` on any secrets that your function needs during runtime
-
-Deployment service account (the SA that executes `gcloud functions deploy`):
-- `roles/cloudfunctions.admin`
-- `roles/iam.serviceAccountUser` on the runtime service account
-
-In some circumstances, your GCP project's google-managed service account for Cloud Build will need:
-- `roles/iam.serviceAccountUser` on the runtime service account
+- the function runtime service account: The service account your function code will be executing as
+- the deployment service account: The service account that will be running `gcloud functions deploy`
+- the project's cloudbuild service account: In some edge cases, it is required to allow the cloudbuild service account to assume the identities of your deployment/runtime accounts.
 
 ## Workload Identity Federation
 
 This module optionally configures workload identity federation with GitHub Actions, to allow the github action to authenticate for function deployment. The default set of conditions that governs what actions will be able to do things is: Only commits to `refs/heads/main` on the [gnomAD storage monitoring](https://github.com/broadinstitute/gnomad-storage-monitoring) repository will be allowed to authenticate.
 
 If you need to use another branch / repository, adjust the `workload_identity_attr_condition` (the assertion rule) and the `workload_identity_attr` (the target repository) accordingly.
-
-You cannot enable workload identity federation via the module if you set `manage_service_accounts` to `false`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -83,23 +74,24 @@ You cannot enable workload identity federation via the module if you set `manage
 | [google_project_iam_member.service_account_project_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_pubsub_topic.scheduled_function_trigger_topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
 | [google_secret_manager_secret_iam_member.function_secret_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
-| [google_service_account.deployment_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account.scheduled_function_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_member.cloudbuild_impersonate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_service_account_iam_member.deployer_impersonate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account.deployment_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account) | data source |
+| [google_service_account.runtime_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cloudbuild_service_account_email"></a> [cloudbuild\_service\_account\_email](#input\_cloudbuild\_service\_account\_email) | The email address of the cloudbuild service account | `string` | n/a | yes |
-| <a name="input_configure_workload_identity"></a> [configure\_workload\_identity](#input\_configure\_workload\_identity) | Whether or not to configure workload identity federation for the scheduled function and github actions. Cannot be specified if manage\_service\_accounts is false | `bool` | `true` | no |
+| <a name="input_cloudbuild_service_account_email"></a> [cloudbuild\_service\_account\_email](#input\_cloudbuild\_service\_account\_email) | The email address of the cloudbuild service account. Needed to allow cloudbuild to assume your deployment accounts identity | `string` | n/a | yes |
+| <a name="input_configure_workload_identity"></a> [configure\_workload\_identity](#input\_configure\_workload\_identity) | Whether or not to configure workload identity federation for the scheduled function and github actions | `bool` | `true` | no |
 | <a name="input_cron_schedule"></a> [cron\_schedule](#input\_cron\_schedule) | A string representing the cron-format schedule for which to trigger the cloud function | `string` | n/a | yes |
-| <a name="input_manage_service_accounts"></a> [manage\_service\_accounts](#input\_manage\_service\_accounts) | Whether or not to manage the service accounts for the scheduled function and the deployment service account | `bool` | `true` | no |
+| <a name="input_deployment_service_account_email"></a> [deployment\_service\_account\_email](#input\_deployment\_service\_account\_email) | The service account which will be used for function deployment actions (e.g. the one that runs gcloud functions deploy) | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project id of the project in which to create the scheduled function | `string` | n/a | yes |
-| <a name="input_required_gcp_secrets"></a> [required\_gcp\_secrets](#input\_required\_gcp\_secrets) | A list of the names of GCP Secret Manager secrets that the scheudled function requires to run. Cannot be specified if manage\_service\_accounts is false | `list(string)` | `[]` | no |
+| <a name="input_required_gcp_secrets"></a> [required\_gcp\_secrets](#input\_required\_gcp\_secrets) | A list of the names of GCP Secret Manager secrets that the scheudled function requires to run | `list(string)` | `[]` | no |
+| <a name="input_runtime_service_account_email"></a> [runtime\_service\_account\_email](#input\_runtime\_service\_account\_email) | The service account which will be used for function runtime actions (e.g. the one that runs your function code) | `string` | n/a | yes |
 | <a name="input_scheduled_function_name"></a> [scheduled\_function\_name](#input\_scheduled\_function\_name) | The string that should be used to create resources associated with the module, svc account, pubsub queue, etc | `string` | n/a | yes |
-| <a name="input_service_account_roles"></a> [service\_account\_roles](#input\_service\_account\_roles) | A list of roles to assign to the service account created for the scheduled function. Cannot be specified if manage\_service\_accounts is false | `list(string)` | `[]` | no |
+| <a name="input_service_account_roles"></a> [service\_account\_roles](#input\_service\_account\_roles) | A list of roles to assign to the service account created for the scheduled function | `list(string)` | `[]` | no |
 | <a name="input_workload_identity_attr"></a> [workload\_identity\_attr](#input\_workload\_identity\_attr) | value of the workload identity attribute to use for the scheduled function workload identity mapping | `string` | `"attribute.repository/broadinstitute/gnomad-storage-monitoring"` | no |
 | <a name="input_workload_identity_attr_condition"></a> [workload\_identity\_attr\_condition](#input\_workload\_identity\_attr\_condition) | The workload identity attribute condition to use for the scheduled function workload identity mapping | `string` | `"assertion.ref=='refs/heads/main'"` | no |
 
@@ -107,8 +99,6 @@ You cannot enable workload identity federation via the module if you set `manage
 
 | Name | Description |
 |------|-------------|
-| <a name="output_deployment_service_account_member"></a> [deployment\_service\_account\_member](#output\_deployment\_service\_account\_member) | n/a |
 | <a name="output_scheduled_function_name"></a> [scheduled\_function\_name](#output\_scheduled\_function\_name) | n/a |
 | <a name="output_scheduled_function_trigger_topic"></a> [scheduled\_function\_trigger\_topic](#output\_scheduled\_function\_trigger\_topic) | n/a |
-| <a name="output_service_account_member"></a> [service\_account\_member](#output\_service\_account\_member) | n/a |
 <!-- END_TF_DOCS -->

--- a/scheduled-cloudfunction/main.tf
+++ b/scheduled-cloudfunction/main.tf
@@ -25,7 +25,7 @@ resource "google_service_account" "scheduled_function_service_account" {
 
 resource "google_service_account_iam_member" "cloudbuild_impersonate" {
   count              = var.manage_service_accounts ? 1 : 0
-  service_account_id = google_service_account.scheduled_function_service_account.name
+  service_account_id = google_service_account.scheduled_function_service_account[0].name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${var.cloudbuild_service_account_email}"
 }
@@ -34,14 +34,14 @@ resource "google_project_iam_member" "service_account_project_permissions" {
   for_each = toset(var.service_account_roles)
   project  = var.project_id
   role     = each.value
-  member   = google_service_account.scheduled_function_service_account.member
+  member   = google_service_account.scheduled_function_service_account[0].member
 }
 
 resource "google_secret_manager_secret_iam_member" "function_secret_access" {
   for_each  = toset(var.required_gcp_secrets)
   secret_id = each.value
   role      = "roles/secretmanager.secretAccessor"
-  member    = google_service_account.scheduled_function_service_account.member
+  member    = google_service_account.scheduled_function_service_account[0].member
 }
 
 resource "google_service_account" "deployment_service_account" {
@@ -55,14 +55,14 @@ resource "google_project_iam_member" "deployment_service_account_project_permiss
   count   = var.manage_service_accounts ? 1 : 0
   project = var.project_id
   role    = "roles/cloudfunctions.admin"
-  member  = google_service_account.deployment_service_account.member
+  member  = google_service_account.deployment_service_account[0].member
 }
 
 resource "google_service_account_iam_member" "deployer_impersonate" {
   count              = var.manage_service_accounts ? 1 : 0
-  service_account_id = google_service_account.scheduled_function_service_account.name
+  service_account_id = google_service_account.scheduled_function_service_account[0].name
   role               = "roles/iam.serviceAccountUser"
-  member             = google_service_account.deployment_service_account.member
+  member             = google_service_account.deployment_service_account[0].member
 }
 
 module "gh_oidc_wif" {
@@ -82,7 +82,7 @@ module "gh_oidc_wif" {
   attribute_condition = var.workload_identity_attr_condition
   sa_mapping = {
     "${var.scheduled_function_name}-deployer" = {
-      sa_name   = google_service_account.deployment_service_account.id
+      sa_name   = google_service_account.deployment_service_account[0].id
       attribute = var.workload_identity_attr
     }
   }
@@ -94,11 +94,11 @@ output "scheduled_function_trigger_topic" {
 }
 
 output "service_account_member" {
-  value = var.manage_service_accounts ? google_service_account.scheduled_function_service_account.member : null
+  value = var.manage_service_accounts ? google_service_account.scheduled_function_service_account[0].member : null
 }
 
 output "deployment_service_account_member" {
-  value = var.manage_service_accounts ? google_service_account.deployment_service_account.member : null
+  value = var.manage_service_accounts ? google_service_account.deployment_service_account[0].member : null
 }
 
 output "scheduled_function_name" {

--- a/scheduled-cloudfunction/main.tf
+++ b/scheduled-cloudfunction/main.tf
@@ -16,16 +16,16 @@ resource "google_cloud_scheduler_job" "cloud_scheduler_schedule" {
   }
 }
 
-resource "google_service_account" "scheduled_function_service_account" {
-  count        = var.manage_service_accounts ? 1 : 0
-  account_id   = var.scheduled_function_name
-  project      = var.project_id
-  display_name = "Service account for scheduled function: ${var.scheduled_function_name}"
+data "google_service_account" "runtime_service_account" {
+  account_id = var.runtime_service_account_email
+}
+
+data "google_service_account" "deployment_service_account" {
+  account_id = var.deployment_service_account_email
 }
 
 resource "google_service_account_iam_member" "cloudbuild_impersonate" {
-  count              = var.manage_service_accounts ? 1 : 0
-  service_account_id = google_service_account.scheduled_function_service_account[0].name
+  service_account_id = data.google_service_account.runtime_service_account.name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${var.cloudbuild_service_account_email}"
 }
@@ -34,35 +34,26 @@ resource "google_project_iam_member" "service_account_project_permissions" {
   for_each = toset(var.service_account_roles)
   project  = var.project_id
   role     = each.value
-  member   = google_service_account.scheduled_function_service_account[0].member
+  member   = data.google_service_account.runtime_service_account.member
 }
 
 resource "google_secret_manager_secret_iam_member" "function_secret_access" {
   for_each  = toset(var.required_gcp_secrets)
   secret_id = each.value
   role      = "roles/secretmanager.secretAccessor"
-  member    = google_service_account.scheduled_function_service_account[0].member
-}
-
-resource "google_service_account" "deployment_service_account" {
-  count        = var.manage_service_accounts ? 1 : 0
-  account_id   = "${var.scheduled_function_name}-deployer"
-  project      = var.project_id
-  display_name = "Service account for scheduled function deployment: ${var.scheduled_function_name}"
+  member    = data.google_service_account.runtime_service_account.member
 }
 
 resource "google_project_iam_member" "deployment_service_account_project_permissions" {
-  count   = var.manage_service_accounts ? 1 : 0
   project = var.project_id
   role    = "roles/cloudfunctions.admin"
-  member  = google_service_account.deployment_service_account[0].member
+  member  = data.google_service_account.deployment_service_account.member
 }
 
 resource "google_service_account_iam_member" "deployer_impersonate" {
-  count              = var.manage_service_accounts ? 1 : 0
-  service_account_id = google_service_account.scheduled_function_service_account[0].name
+  service_account_id = data.google_service_account.runtime_service_account.name
   role               = "roles/iam.serviceAccountUser"
-  member             = google_service_account.deployment_service_account[0].member
+  member             = data.google_service_account.deployment_service_account.member
 }
 
 module "gh_oidc_wif" {
@@ -82,7 +73,7 @@ module "gh_oidc_wif" {
   attribute_condition = var.workload_identity_attr_condition
   sa_mapping = {
     "${var.scheduled_function_name}-deployer" = {
-      sa_name   = google_service_account.deployment_service_account[0].id
+      sa_name   = data.google_service_account.deployment_service_account.id
       attribute = var.workload_identity_attr
     }
   }
@@ -91,14 +82,6 @@ module "gh_oidc_wif" {
 
 output "scheduled_function_trigger_topic" {
   value = google_pubsub_topic.scheduled_function_trigger_topic.name
-}
-
-output "service_account_member" {
-  value = var.manage_service_accounts ? google_service_account.scheduled_function_service_account[0].member : null
-}
-
-output "deployment_service_account_member" {
-  value = var.manage_service_accounts ? google_service_account.deployment_service_account[0].member : null
 }
 
 output "scheduled_function_name" {

--- a/scheduled-cloudfunction/main.tf
+++ b/scheduled-cloudfunction/main.tf
@@ -1,11 +1,9 @@
 resource "google_pubsub_topic" "scheduled_function_trigger_topic" {
-  name    = var.scheduled_function_name
-  project = var.project_id
+  name = var.scheduled_function_name
 }
 
 resource "google_cloud_scheduler_job" "cloud_scheduler_schedule" {
   name        = var.scheduled_function_name
-  project     = var.project_id
   description = "Cron schedule for: ${var.scheduled_function_name}"
   schedule    = var.cron_schedule
   time_zone   = "America/New_York"

--- a/scheduled-cloudfunction/variables.tf
+++ b/scheduled-cloudfunction/variables.tf
@@ -13,21 +13,25 @@ variable "cron_schedule" {
   description = "A string representing the cron-format schedule for which to trigger the cloud function"
 }
 
-variable "manage_service_accounts" {
-  type        = bool
-  description = "Whether or not to manage the service accounts for the scheduled function and the deployment service account"
-  default     = true
+variable "deployment_service_account_email" {
+  type        = string
+  description = "The service account which will be used for function deployment actions (e.g. the one that runs gcloud functions deploy)"
+}
+
+variable "runtime_service_account_email" {
+  type        = string
+  description = "The service account which will be used for function runtime actions (e.g. the one that runs your function code)"
+}
+
+variable "cloudbuild_service_account_email" {
+  type        = string
+  description = "The email address of the cloudbuild service account. Needed to allow cloudbuild to assume your deployment accounts identity"
 }
 
 variable "service_account_roles" {
   type        = list(string)
   description = "A list of roles to assign to the service account created for the scheduled function. Cannot be specified if manage_service_accounts is false"
   default     = []
-}
-
-variable "cloudbuild_service_account_email" {
-  type        = string
-  description = "The email address of the cloudbuild service account"
 }
 
 variable "required_gcp_secrets" {

--- a/scheduled-cloudfunction/variables.tf
+++ b/scheduled-cloudfunction/variables.tf
@@ -30,13 +30,13 @@ variable "cloudbuild_service_account_email" {
 
 variable "service_account_roles" {
   type        = list(string)
-  description = "A list of roles to assign to the service account created for the scheduled function. Cannot be specified if manage_service_accounts is false"
+  description = "A list of roles to assign to the service account created for the scheduled function"
   default     = []
 }
 
 variable "required_gcp_secrets" {
   type        = list(string)
-  description = "A list of the names of GCP Secret Manager secrets that the scheudled function requires to run. Cannot be specified if manage_service_accounts is false"
+  description = "A list of the names of GCP Secret Manager secrets that the scheudled function requires to run"
   default     = []
 }
 
@@ -47,7 +47,7 @@ variable "project_id" {
 
 variable "configure_workload_identity" {
   type        = bool
-  description = "Whether or not to configure workload identity federation for the scheduled function and github actions. Cannot be specified if manage_service_accounts is false"
+  description = "Whether or not to configure workload identity federation for the scheduled function and github actions"
   default     = true
 }
 

--- a/scheduled-cloudfunction/variables.tf
+++ b/scheduled-cloudfunction/variables.tf
@@ -1,54 +1,11 @@
 variable "scheduled_function_name" {
   type        = string
-  description = "The string that should be used to create resources associated with the module, pubsub queue, etc"
+  description = "The string that should be used to create resources associated with the module, svc account, pubsub queue, etc"
 
   validation {
-    condition     = length(var.scheduled_function_name) < 32
+    condition     = length(var.scheduled_function_name) >= 6 && length(var.scheduled_function_name) < 30
     error_message = "The name_prefix must be less than 32 characters to conform to google's naming requirements."
   }
-}
-
-variable "scheduled_function_description" {
-  type        = string
-  description = "The string that should be used as the scheduled function description"
-}
-
-variable "service_account_email" {
-  type        = string
-  description = "A string representing the email address of the serviceAccount that the cloudfunction should run as."
-
-  validation {
-    condition     = substr(var.service_account_email, -19, -1) == "gserviceaccount.com"
-    error_message = "The service account email must end in gserviceaccount.com."
-  }
-}
-
-variable "function_environment_variables" {
-  type        = map(string)
-  default     = {}
-  description = "A set of key/value environment variables to pass to the function."
-}
-
-variable "function_runtime" {
-  type        = string
-  default     = "python39"
-  description = "The cloudfunction runtime that should be used for the function, e.g. python39."
-}
-
-variable "function_entrypoint" {
-  type        = string
-  description = "The entrypoint (main function name) that cloudfunctions should use to invoke the function"
-}
-
-variable "memory_mb" {
-  type        = number
-  default     = 128
-  description = "Number of megabytes to allocate to the cloud functon. Default 128"
-}
-
-variable "source_repository_url" {
-  type        = string
-  description = "The URL of the google Source Repository object, see: https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#SourceRepository"
 }
 
 variable "cron_schedule" {
@@ -56,25 +13,24 @@ variable "cron_schedule" {
   description = "A string representing the cron-format schedule for which to trigger the cloud function"
 }
 
-variable "function_timeout" {
-  type        = number
-  default     = 60
-  description = "The number of seconds that the function is allowed to execute."
-
-  validation {
-    condition     = var.function_timeout >= 10 && var.function_timeout <= 540
-    error_message = "The function_timeout must be greater than or equal to 10, and less than or equal to 540."
-  }
+variable "service_account_roles" {
+  type        = list(string)
+  description = "A list of roles to assign to the service account created for the scheduled function"
+  default     = ["roles/cloudfunctions.invoker"]
 }
 
-variable "min_instances" {
-  type        = number
-  default     = 0
-  description = "The minimum number of function instances that should be running. Set to non-zero to ensure always-available capacity."
+variable "cloudbuild_service_account_email" {
+  type        = string
+  description = "The email address of the cloudbuild service account"
 }
 
-variable "max_instances" {
-  type        = number
-  default     = 3000
-  description = "The maximum number of function instance that should be allowed to run. Google default is 3000."
+variable "required_gcp_secrets" {
+  type        = list(string)
+  description = "A list of the names of GCP Secret Manager secrets that the scheudled function requires to run"
+  default     = []
+}
+
+variable "project_id" {
+  type        = string
+  description = "The project id of the project in which to create the scheduled function"
 }

--- a/scheduled-cloudfunction/variables.tf
+++ b/scheduled-cloudfunction/variables.tf
@@ -34,3 +34,15 @@ variable "project_id" {
   type        = string
   description = "The project id of the project in which to create the scheduled function"
 }
+
+variable "workload_identity_attr_condition" {
+  type        = string
+  description = "The workload identity attribute condition to use for the scheduled function workload identity mapping"
+  default     = "assertion.ref=='refs/heads/main'"
+}
+
+variable "workload_identity_attr" {
+  type        = string
+  description = "value of the workload identity attribute to use for the scheduled function workload identity mapping"
+  default     = "attribute.repository/broadinstitute/gnomad-storage-monitoring"
+}

--- a/scheduled-cloudfunction/variables.tf
+++ b/scheduled-cloudfunction/variables.tf
@@ -13,10 +13,16 @@ variable "cron_schedule" {
   description = "A string representing the cron-format schedule for which to trigger the cloud function"
 }
 
+variable "manage_service_accounts" {
+  type        = bool
+  description = "Whether or not to manage the service accounts for the scheduled function and the deployment service account"
+  default     = true
+}
+
 variable "service_account_roles" {
   type        = list(string)
-  description = "A list of roles to assign to the service account created for the scheduled function"
-  default     = ["roles/cloudfunctions.invoker"]
+  description = "A list of roles to assign to the service account created for the scheduled function. Cannot be specified if manage_service_accounts is false"
+  default     = []
 }
 
 variable "cloudbuild_service_account_email" {
@@ -26,13 +32,19 @@ variable "cloudbuild_service_account_email" {
 
 variable "required_gcp_secrets" {
   type        = list(string)
-  description = "A list of the names of GCP Secret Manager secrets that the scheudled function requires to run"
+  description = "A list of the names of GCP Secret Manager secrets that the scheudled function requires to run. Cannot be specified if manage_service_accounts is false"
   default     = []
 }
 
 variable "project_id" {
   type        = string
   description = "The project id of the project in which to create the scheduled function"
+}
+
+variable "configure_workload_identity" {
+  type        = bool
+  description = "Whether or not to configure workload identity federation for the scheduled function and github actions. Cannot be specified if manage_service_accounts is false"
+  default     = true
 }
 
 variable "workload_identity_attr_condition" {

--- a/scheduled-cloudfunction/variables.tf
+++ b/scheduled-cloudfunction/variables.tf
@@ -4,7 +4,7 @@ variable "scheduled_function_name" {
 
   validation {
     condition     = length(var.scheduled_function_name) >= 6 && length(var.scheduled_function_name) < 30
-    error_message = "The name_prefix must be less than 32 characters to conform to google's naming requirements."
+    error_message = "The function name must be greater than 6 chars and less than 30 characters to conform to google's naming requirements."
   }
 }
 

--- a/scheduled-cloudfunction/versions.tf
+++ b/scheduled-cloudfunction/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.42.0"
+    }
+  }
+}


### PR DESCRIPTION
The way this module worked previously, as prerequisites it required:

- configuring a google cloud source repo mirror of the function source
- provisioning a service account and setting its permissions
- configuring a github action or cloudbuild trigger to automatically update the function code if it changed on github

The first two steps were a pain, and the third step made the `google_cloudfunctions_function` resource in terraform completely redundant.

Instead, what this module will now do is provision all the GCP stuff (service account, IAM permissions, pubsub, cloud scheduler) and then output the details necessary to finish configuring the function deployment on the github side of things.

This is a breaking change, so we'll have a major semver bump to 1.0.0. I added some upgrade notes to the readme, and also used `terraform-docs` to generate the variable inputs and module output docs that were previously missing.