### PR TITLE
allow batch svc accounts to bill bandwidth to sandboxes

### DIFF
--- a/gnomad-google-project/project.tf
+++ b/gnomad-google-project/project.tf
@@ -109,6 +109,7 @@ resource "google_project_iam_member" "hail_batch_artifact_read" {
   member  = "serviceAccount:${var.hail_batch_service_account}"
 }
 
+# Grant serviceusage.use permissions to Batch SA (allow SA to use project)
 resource "google_project_iam_member" "hail_batch_service_usage" {
   count   = length(var.hail_batch_service_account) > 0 ? 1 : 0
   project = google_project.current_project.project_id

--- a/gnomad-google-project/project.tf
+++ b/gnomad-google-project/project.tf
@@ -109,6 +109,13 @@ resource "google_project_iam_member" "hail_batch_artifact_read" {
   member  = "serviceAccount:${var.hail_batch_service_account}"
 }
 
+resource "google_project_iam_member" "hail_batch_service_usage" {
+  count   = length(var.hail_batch_service_account) > 0 ? 1 : 0
+  project = google_project.current_project.project_id
+  role    = "roles/serviceusage.serviceUsageConsumer"
+  member  = "serviceAccount:${var.hail_batch_service_account}"
+}
+
 resource "google_project_iam_member" "billing_manager_access" {
   count   = var.enable_cost_control ? 1 : 0
   project = google_project.current_project.project_id


### PR DESCRIPTION
Batch service accounts were being given the ability to read all the storage, but couldn't actually _use_ the project or bill network bandwidth if a userProject was provided in an API request. This should fix that gap.