### PR TITLE
Adds hooks for application level security and network policies

### DIFF
--- a/gnomad-browser-infra/variables.tf
+++ b/gnomad-browser-infra/variables.tf
@@ -116,3 +116,15 @@ variable "data_pipeline_bucket_location" {
   type        = string
   default     = "us-east1"
 }
+
+variable "gke_kms_keyring_location" {
+  description = "The location of the KMS keyring to use for GKE database encryption. Must match the region your cluster is deployed in"
+  type        = string
+  default     = "us-east1"
+}
+
+variable "gke_kms_key_prevent_destroy" {
+  description = "value to set the lifecycle prevent_destroy flag on the KMS key. Set to false before destroying your cluster"
+  type        = bool
+  default     = true
+}

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -104,8 +104,8 @@ resource "google_container_cluster" "gke_cluster" {
     for_each = var.gke_database_encryption_config
 
     content {
-      state = database_encryption.value.state
-      key   = database_encryption.value.key
+      state    = database_encryption.value.state
+      key_name = database_encryption.value.key
     }
   }
 }

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -98,6 +98,16 @@ resource "google_container_cluster" "gke_cluster" {
         enabled  = network_policy.value.enabled
       }
     }
+
+    dynamic "database_encryption" {
+      for_each = var.gke_database_encryption
+
+      content {
+        state = database_encryption.value.state
+        key   = database_encryption.value.key
+      }
+    }
+
   }
 }
 

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -83,6 +83,21 @@ resource "google_container_cluster" "gke_cluster" {
 
       }
     }
+
+    addons_config {
+      network_policy_config {
+        disabled = !var.gke_network_policy_enabled
+      }
+    }
+
+    dynamic "network_policy" {
+      for_each = var.gke_network_policy
+
+      content {
+        provider = network_policy.value.provider
+        enabled  = network_policy.value.enabled
+      }
+    }
   }
 }
 

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -83,31 +83,30 @@ resource "google_container_cluster" "gke_cluster" {
 
       }
     }
+  }
 
-    addons_config {
-      network_policy_config {
-        disabled = !var.gke_network_policy_enabled
-      }
+  addons_config {
+    network_policy_config {
+      disabled = !var.gke_network_policy_enabled
     }
+  }
 
-    dynamic "network_policy" {
-      for_each = var.gke_network_policy
+  dynamic "network_policy" {
+    for_each = var.gke_network_policy
 
-      content {
-        provider = network_policy.value.provider
-        enabled  = network_policy.value.enabled
-      }
+    content {
+      provider = network_policy.value.provider
+      enabled  = network_policy.value.enabled
     }
+  }
 
-    dynamic "database_encryption" {
-      for_each = var.gke_database_encryption
+  dynamic "database_encryption" {
+    for_each = var.gke_database_encryption_config
 
-      content {
-        state = database_encryption.value.state
-        key   = database_encryption.value.key
-      }
+    content {
+      state = database_encryption.value.state
+      key   = database_encryption.value.key
     }
-
   }
 }
 

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -125,3 +125,12 @@ variable "gke_network_policy" {
     enabled  = false
   }]
 }
+
+variable "gke_database_encryption_config" {
+  description = "Configs and KMS key IDs for etcd/secrets database encryption"
+  type = list(object({
+    state = string # one of "ENCRYPTED", "DECRYPTED"
+    key   = string # projects/MY_PROJECT/locations/global/keyRings/MY_KEYRING/cryptoKeys/MY_KEY
+  }))
+  default = []
+}

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -105,3 +105,23 @@ variable "gke_maint_exclusions" {
   type        = list(map(string))
   default     = []
 }
+
+# Network Policy Configuration
+# When enabled, uses the default network policy provider to satisfy BITS infosec requirements
+variable "gke_network_policy_enabled" {
+  description = "Whether to enable the GKE network policy addon"
+  type        = bool
+  default     = false
+}
+
+variable "gke_network_policy" {
+  description = "The network provider definition to be used when network policies are enabled"
+  type = list(object({
+    provider = string
+    enabled  = bool
+  }))
+  default = [{
+    provider = "PROVIDER_UNSPECIFIED"
+    enabled  = false
+  }]
+}

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -121,7 +121,7 @@ variable "gke_network_policy" {
     enabled  = bool
   }))
   default = [{
-    provider = "PROVIDER_UNSPECIFIED"
+    provider = "CALICO"
     enabled  = false
   }]
 }


### PR DESCRIPTION
This adds hooks to private-gke-cluster to abide by two new infosec rules: We can now enable application level secrets encryption and enable gke network policies. Both are off by default.

This also updates the gnomad-browser-infra modules to use these new hooks, and enable them in our environments.

Turning these on in existing clusters appears to be (mostly) non-disruptive, but should be done after hours just in case. I have not yet tested the effects of the network policies, so i need to double check that this doesn't interrupt any of the inter-pod network traffic that we currently depend on.