### PR TITLE
adds support for auto-configuring the gnomad proxy-ips configmap

### DIFF
--- a/gnomad-browser-infra/README.md
+++ b/gnomad-browser-infra/README.md
@@ -7,6 +7,16 @@ This module configures the base set of cloud infrastructure for the [gnomAD Brow
 This module can be used by including a module block in your terraform configuration, using a [github module source block](https://developer.hashicorp.com/terraform/language/modules/sources#github), and providing the [required inputs](#inputs):
 
 ```terraform
+data "google_client_config" "tf_sa" {}
+
+provider "kubernetes" {
+  host  = "https://${module.gnomad-browser-infra.gke_cluster_api_endpoint}"
+  token = data.google_client_config.tf_sa.access_token
+  cluster_ca_certificate = base64decode(
+    module.gnomad-browser-infra.gke_cluster_ca_cert,
+  )
+}
+
 module "gnomad-browser-infra" {
   source = "github.com/broadinstitute/tgg-terraform-modules//gnomad-browser-infra?ref=<git commit SHA ID or Tag>"
   infra_prefix = "my-gnomad-browser"
@@ -23,19 +33,7 @@ module "gnomad-browser-infra" {
 
 The module was updated in 1.0.0 to handle the creation of a kubernetes configmap, a kubernetes service account, and the static IP reservation was removed from the module. In order for a pre-1.0 config to work, **before applying**, you need:
 
-- To configure the kubernetes provider with the gnomad-browser-infra's authentication endpoint outputs:
-
-```
-data "google_client_config" "tf_sa" {}
-
-provider "kubernetes" {
-  host  = "https://${module.gnomad-browser-infra.gke_cluster_api_endpoint}"
-  token = data.google_client_config.tf_sa.access_token
-  cluster_ca_certificate = base64decode(
-    module.gnomad-browser-infra.gke_cluster_ca_cert,
-  )
-}
-```
+- To configure the kubernetes provider with the gnomad-browser-infra's authentication endpoint outputs, as documented above in [Usage](#usage)
 
 - If they already exist, import the proxy-ips configmap and es-snaps service account into your configuration:
 

--- a/gnomad-browser-infra/README.md
+++ b/gnomad-browser-infra/README.md
@@ -56,25 +56,26 @@ serviceAccountName: es-snaps
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.45.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.23.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 4.45.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.23.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_gnomad-gke"></a> [gnomad-gke](#module\_gnomad-gke) | github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster | private-gke-cluster-v1.0.0 |
+| <a name="module_gnomad-gke"></a> [gnomad-gke](#module\_gnomad-gke) | github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster | automate-proxy-ips |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [google_compute_firewall.es_webbook](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
-| [google_compute_global_address.public_ingress](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_project_iam_member.data_pipeline_dataproc_worker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.data_pipeline_service_consumer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.data_pipeline](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
@@ -84,6 +85,8 @@ serviceAccountName: es-snaps
 | [google_storage_bucket.elastic_snapshots](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_member.data_pipeline](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.es_snapshots](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [kubernetes_config_map.gnomad_proxy_ips](https://registry.terraform.io/providers/hashicorp/kubernetes/2.23.0/docs/resources/config_map) | resource |
+| [google_compute_subnetwork.gke_vpc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 
 ## Inputs
 
@@ -95,9 +98,12 @@ serviceAccountName: es-snaps
 | <a name="input_gke_control_plane_zone"></a> [gke\_control\_plane\_zone](#input\_gke\_control\_plane\_zone) | The GCP zone where the GKE control plane will reside | `string` | `"us-east1-c"` | no |
 | <a name="input_gke_maint_exclusions"></a> [gke\_maint\_exclusions](#input\_gke\_maint\_exclusions) | Specified times and dates that non-emergency GKE maintenance should pause | `list(map(string))` | `[]` | no |
 | <a name="input_gke_node_pools"></a> [gke\_node\_pools](#input\_gke\_node\_pools) | A list of node pools and their configuration that should be created within the GKE cluster; pools with an empty string for the zone will deploy in the same region as the control plane | <pre>list(object({<br>    pool_name            = string<br>    pool_num_nodes       = number<br>    pool_machine_type    = string<br>    pool_preemptible     = bool<br>    pool_zone            = string<br>    pool_resource_labels = map(string)<br>  }))</pre> | <pre>[<br>  {<br>    "pool_machine_type": "e2-standard-4",<br>    "pool_name": "main-pool",<br>    "pool_num_nodes": 2,<br>    "pool_preemptible": false,<br>    "pool_resource_labels": {},<br>    "pool_zone": ""<br>  },<br>  {<br>    "pool_machine_type": "e2-custom-6-49152",<br>    "pool_name": "redis",<br>    "pool_num_nodes": 1,<br>    "pool_preemptible": false,<br>    "pool_resource_labels": {<br>      "component": "redis"<br>    },<br>    "pool_zone": ""<br>  },<br>  {<br>    "pool_machine_type": "e2-highmem-8",<br>    "pool_name": "es-data",<br>    "pool_num_nodes": 3,<br>    "pool_preemptible": false,<br>    "pool_resource_labels": {<br>      "component": "elasticsearch"<br>    },<br>    "pool_zone": ""<br>  }<br>]</pre> | no |
+| <a name="input_gke_pods_range_slice"></a> [gke\_pods\_range\_slice](#input\_gke\_pods\_range\_slice) | The full (e.g. 10.0.0.0/14) or simple (e.g. /14) CIDR range slice to assign for internal pod IP addresses | `string` | `"/14"` | no |
 | <a name="input_gke_recurring_maint_windows"></a> [gke\_recurring\_maint\_windows](#input\_gke\_recurring\_maint\_windows) | A start time, end time and recurrence pattern for GKE automated maintenance windows | `list(map(string))` | <pre>[<br>  {<br>    "end_time": "1970-01-01T11:00:00Z",<br>    "recurrence": "FREQ=DAILY",<br>    "start_time": "1970-01-01T07:00:00Z"<br>  }<br>]</pre> | no |
+| <a name="input_gke_services_range_slice"></a> [gke\_services\_range\_slice](#input\_gke\_services\_range\_slice) | The full (e.g. 10.0.0.0/20) or simple (e.g. /20) CIDR range slice to assign for internal service IP addresses | `string` | `"/20"` | no |
 | <a name="input_infra_prefix"></a> [infra\_prefix](#input\_infra\_prefix) | The string to use for a prefix on resource names (GKE cluster, GCS Buckets, Service Accounts, etc) | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The name of the target GCP project, for creating IAM memberships | `string` | n/a | yes |
+| <a name="input_public_static_ip"></a> [public\_static\_ip](#input\_public\_static\_ip) | The public IP address that has been reserved for your browser | `string` | `null` | no |
 | <a name="input_vpc_network_name"></a> [vpc\_network\_name](#input\_vpc\_network\_name) | The name of the VPC network that the GKE cluster should reside in | `string` | n/a | yes |
 | <a name="input_vpc_subnet_name"></a> [vpc\_subnet\_name](#input\_vpc\_subnet\_name) | The name of the VPC network subnet that the GKE cluster nodes should reside in | `string` | n/a | yes |
 
@@ -105,8 +111,10 @@ serviceAccountName: es-snaps
 
 | Name | Description |
 |------|-------------|
+| <a name="output_gke_cluster_api_endpoint"></a> [gke\_cluster\_api\_endpoint](#output\_gke\_cluster\_api\_endpoint) | n/a |
+| <a name="output_gke_cluster_ca_cert"></a> [gke\_cluster\_ca\_cert](#output\_gke\_cluster\_ca\_cert) | n/a |
 | <a name="output_gke_cluster_name"></a> [gke\_cluster\_name](#output\_gke\_cluster\_name) | n/a |
-| <a name="output_public_web_address"></a> [public\_web\_address](#output\_public\_web\_address) | n/a |
+| <a name="output_gke_pods_ipv4_cidr_block"></a> [gke\_pods\_ipv4\_cidr\_block](#output\_gke\_pods\_ipv4\_cidr\_block) | for obtaining the internal network value that should be set in gnomad's PROXY\_IPS env variable |
 <!-- END_TF_DOCS -->
 
 ## Misc

--- a/gnomad-browser-infra/README.md
+++ b/gnomad-browser-infra/README.md
@@ -69,7 +69,7 @@ serviceAccountName: es-snaps
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_gnomad-gke"></a> [gnomad-gke](#module\_gnomad-gke) | github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster | automate-proxy-ips |
+| <a name="module_gnomad-gke"></a> [gnomad-gke](#module\_gnomad-gke) | github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster | private-gke-cluster-v1.0.3 |
 
 ## Resources
 
@@ -86,6 +86,7 @@ serviceAccountName: es-snaps
 | [google_storage_bucket_iam_member.data_pipeline](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.es_snapshots](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [kubernetes_config_map.gnomad_proxy_ips](https://registry.terraform.io/providers/hashicorp/kubernetes/2.23.0/docs/resources/config_map) | resource |
+| [kubernetes_service_account.es_snaps](https://registry.terraform.io/providers/hashicorp/kubernetes/2.23.0/docs/resources/service_account) | resource |
 | [google_compute_subnetwork.gke_vpc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 
 ## Inputs

--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -70,7 +70,7 @@ resource "google_storage_bucket" "data_pipeline" {
 }
 
 module "gnomad-gke" {
-  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=automate-proxy-ips"
+  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=private-gke-cluster-v1.0.3"
   gke_cluster_name       = var.infra_prefix
   project_name           = var.project_id
   gke_control_plane_zone = var.gke_control_plane_zone

--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -104,12 +104,12 @@ resource "google_compute_firewall" "es_webbook" {
   target_tags   = ["${var.infra_prefix}-gke"]
 }
 
-resource "google_compute_global_address" "public_ingress" {
-  name = "${var.infra_prefix}-global-ip"
-}
-
 data "google_compute_subnetwork" "gke_vpc" {
   name = var.vpc_subnet_name
+}
+
+locals {
+  static_ip = var.public_static_ip == null ? "" : ",${var.public_static_ip}"
 }
 
 resource "kubernetes_config_map" "gnomad_proxy_ips" {
@@ -117,6 +117,6 @@ resource "kubernetes_config_map" "gnomad_proxy_ips" {
     name = "proxy-ips"
   }
   data = {
-    ips = "127.0.0.1,${data.google_compute_subnetwork.gke_vpc.ip_cidr_range},${module.gnomad-gke.gke_pods_ipv4_cidr_block},${module.gnomad-gke.gke_services_ipv4_cidr_block},35.191.0.0/16,130.211.0.0/22,${google_compute_global_address.public_ingress.address}"
+    ips = "127.0.0.1,${data.google_compute_subnetwork.gke_vpc.ip_cidr_range},${module.gnomad-gke.gke_pods_ipv4_cidr_block},${module.gnomad-gke.gke_services_ipv4_cidr_block},35.191.0.0/16,130.211.0.0/22${local.static_ip}"
   }
 }

--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -107,3 +107,16 @@ resource "google_compute_firewall" "es_webbook" {
 resource "google_compute_global_address" "public_ingress" {
   name = "${var.infra_prefix}-global-ip"
 }
+
+data "google_compute_subnetwork" "gke_vpc" {
+  name = var.vpc_subnet_name
+}
+
+resource "kubernetes_config_map" "gnomad_proxy_ips" {
+  metadata {
+    name = "proxy-ips"
+  }
+  data = {
+    ips = "127.0.0.1,${data.google_compute_subnetwork.gke_vpc.ip_cidr_range},${module.gnomad-gke.gke_pods_ipv4_cidr_block},${module.gnomad-gke.gke_services_ipv4_cidr_block},35.191.0.0/16,130.211.0.0/22,${google_compute_global_address.public_ingress.address}"
+  }
+}

--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -70,7 +70,7 @@ resource "google_storage_bucket" "data_pipeline" {
 }
 
 module "gnomad-gke" {
-  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=private-gke-cluster-v1.0.2"
+  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=automate-proxy-ips"
   gke_cluster_name       = var.infra_prefix
   project_name           = var.project_id
   gke_control_plane_zone = var.gke_control_plane_zone

--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -112,11 +112,22 @@ locals {
   static_ip = var.public_static_ip == null ? "" : ",${var.public_static_ip}"
 }
 
+# Expected configuration for the browser deployments PROXY_IPS environment variable
 resource "kubernetes_config_map" "gnomad_proxy_ips" {
   metadata {
     name = "proxy-ips"
   }
   data = {
     ips = "127.0.0.1,${data.google_compute_subnetwork.gke_vpc.ip_cidr_range},${module.gnomad-gke.gke_pods_ipv4_cidr_block},${module.gnomad-gke.gke_services_ipv4_cidr_block},35.191.0.0/16,130.211.0.0/22${local.static_ip}"
+  }
+}
+
+# Pre-configures the service account that we use for ES snapshots
+resource "kubernetes_service_account" "es_snaps" {
+  metadata {
+    name = "es-snaps"
+    annotations = {
+      "iam.gke.io/gcp-service-account" = google_service_account.es_snapshots.email
+    }
   }
 }

--- a/gnomad-browser-infra/outputs.tf
+++ b/gnomad-browser-infra/outputs.tf
@@ -10,3 +10,11 @@ output "gke_cluster_name" {
 output "gke_pods_ipv4_cidr_block" {
   value = module.gnomad-gke.gke_pods_ipv4_cidr_block
 }
+
+output "gke_cluster_api_endpoint" {
+  value = module.gnomad-gke.gke_cluster_api_endpoint
+}
+
+output "gke_cluster_ca_cert" {
+  value = module.gnomad-gke.gke_cluster_ca_cert
+}

--- a/gnomad-browser-infra/outputs.tf
+++ b/gnomad-browser-infra/outputs.tf
@@ -1,7 +1,3 @@
-output "public_web_address" {
-  value = google_compute_global_address.public_ingress.address
-}
-
 output "gke_cluster_name" {
   value = module.gnomad-gke.gke_cluster_name
 }

--- a/gnomad-browser-infra/variables.tf
+++ b/gnomad-browser-infra/variables.tf
@@ -116,3 +116,10 @@ variable "data_pipeline_bucket_location" {
   type        = string
   default     = "us-east1"
 }
+
+
+variable "public_static_ip" {
+  description = "The public IP address that has been reserved for your browser"
+  type        = string
+  default     = null
+}

--- a/gnomad-browser-infra/versions.tf
+++ b/gnomad-browser-infra/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 4.45.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.23.0"
+    }
   }
 }

--- a/private-gke-cluster/outputs.tf
+++ b/private-gke-cluster/outputs.tf
@@ -17,3 +17,17 @@ output "gke_control_plane_cidr" {
 output "gke_pods_ipv4_cidr_block" {
   value = google_container_cluster.gke_cluster.ip_allocation_policy[0].cluster_ipv4_cidr_block
 }
+
+output "gke_services_ipv4_cidr_block" {
+  value = google_container_cluster.gke_cluster.ip_allocation_policy[0].services_ipv4_cidr_block
+}
+
+# cluster API endpoint
+output "gke_cluster_api_endpoint" {
+  value = google_container_cluster.gke_cluster.endpoint
+}
+
+# cluster CA certificate
+output "gke_cluster_ca_cert" {
+  value = google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate
+}


### PR DESCRIPTION
When we moved from the python script to terraform for infra provisioning, we forgot to migrate the step of configuring the gnomad browser's proxy-ips configmap (https://github.com/broadinstitute/gnomad-browser/issues/1207). This is a wonky one, because the configmap should really be part of the app deployment, but it isn't currently, and we don't have a fantastic way to get variables about the GKE cluster's network to the pods in the browser deployment.

Until the app deployment is overhauled to better support variables in its deployment, we can fairly simply write the configmap with terraform. The side benefit of this is that it updates the private-gke-cluster module to output the information required to use the kubernetes terraform provider, for manipulating objects inside GKE clusters, installing helm charts, etc. I've taken advantage of this to auto-configure the service account we use for elasticsearch snapshots.

summary of changes:
- adds authentication outputs to the gke cluster module
- remove the static IP reservation from inside the browser-infra module so that it can be more flexibly managed elsewhere
- creates a configmap on the browser-infra GKE clusters with the information required for setting the `PROXY_IPS` environment variable in the browser deployment.
- Automatically create the es-snaps service account and assign it the workload identity annotation.