### PR TITLE
Allow for stable nat outbound IPs

### DIFF
--- a/vpc-with-nat-subnet/README.md
+++ b/vpc-with-nat-subnet/README.md
@@ -30,6 +30,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_nat_ip_allocate_option"></a> [nat\_ip\_allocate\_option](#input\_nat\_ip\_allocate\_option) | AUTO\_ONLY or MANUAL\_ONLY, for configuring a stable outbound IP | `string` | `"AUTO_ONLY"` | no |
+| <a name="input_nat_ips"></a> [nat\_ips](#input\_nat\_ips) | A list of self\_links to static IP reservations used as stable outbound IPs | `list(string)` | `null` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name that should be given to the VPC network | `string` | `"atlantis"` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | The subnet definitions that you'd like to create for the network | <pre>list(object({<br>    subnet_name_suffix           = string<br>    subnet_region                = string<br>    ip_cidr_range                = string<br>    enable_private_google_access = bool<br>    subnet_flow_logs             = bool<br>    subnet_flow_logs_sampling    = string<br>    subnet_flow_logs_metadata    = string<br>    subnet_flow_logs_filter      = string<br>  }))</pre> | <pre>[<br>  {<br>    "enable_private_google_access": true,<br>    "ip_cidr_range": "192.168.0.0/20",<br>    "subnet_flow_logs": false,<br>    "subnet_flow_logs_filter": "true",<br>    "subnet_flow_logs_metadata": "EXCLUDE_ALL_METADATA",<br>    "subnet_flow_logs_sampling": "0.5",<br>    "subnet_name_suffix": "gke",<br>    "subnet_region": "us-central1"<br>  }<br>]</pre> | no |
 

--- a/vpc-with-nat-subnet/main.tf
+++ b/vpc-with-nat-subnet/main.tf
@@ -37,7 +37,8 @@ resource "google_compute_router_nat" "router_nat" {
   name                               = "${var.network_name}-router-nat"
   router                             = google_compute_router.router.name
   region                             = google_compute_router.router.region
-  nat_ip_allocate_option             = "AUTO_ONLY"
+  nat_ip_allocate_option             = var.nat_ip_allocate_option
+  nat_ips                            = var.nat_ips
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 
   log_config {

--- a/vpc-with-nat-subnet/variables.tf
+++ b/vpc-with-nat-subnet/variables.tf
@@ -29,3 +29,15 @@ variable "subnets" {
     }
   ]
 }
+
+variable "nat_ip_allocate_option" {
+  description = "AUTO_ONLY or MANUAL_ONLY, for configuring a stable outbound IP"
+  type        = string
+  default     = "AUTO_ONLY"
+}
+
+variable "nat_ips" {
+  description = "A list of self_links to static IP reservations used as stable outbound IPs"
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
We have a shortly upcoming use case (#29) where we need to create a firewall rule that allows Atlantis to connect to a kubernetes cluster to create a configmap and k8s service account on it.

By default, cloud NAT uses dynamically provisioned IPs for outbound NAT traffic, and it doesn't tell you what they are (or whether they're actually stable... it's possible that your outbound traffic uses a number of different IPs from a range). This change allows you to reserve one or more static IPs, and pass that into the cloud nat router resource for use as stable outbound IPs. Default use case of auto-provisioned won't change, so that shouldn't break any existing nets.