### PR TITLE
add a service account, bucket, and IAM bindings for gnomad-api

### DIFF
--- a/gnomad-browser-infra/variables.tf
+++ b/gnomad-browser-infra/variables.tf
@@ -117,7 +117,11 @@ variable "data_pipeline_bucket_location" {
   default     = "us-east1"
 }
 
-
+variable "gene_cache_bucket_location" {
+  description = "The GCS location for the JSON gene cache bucket"
+  type        = string
+  default     = "us-east1"
+}
 variable "public_static_ip" {
   description = "The public IP address that has been reserved for your browser"
   type        = string


### PR DESCRIPTION
The need to read and write from a storage bucket on the gnomad-api has arisen, and this updates our module to create a dedicated service account for the API pods.

in all, changes here are:
- create a GCS bucket for the API pods to cache to
- create a service account that can read/write objects to that bucket
- create a workload identity binding so the gnomad-api _kubernetes_ service account can use the GCP service account identity
- reorganize the service accounts, buckets, and IAM bindings throughout the module so that they are grouped by task (ES Snapshots, data pipeline, API pods).