### PR TITLE
Node taint and spot node support

### DIFF
--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -107,7 +107,7 @@ resource "google_storage_bucket_iam_member" "gene_cache" {
 
 # GKE Cluster
 module "gnomad-gke" {
-  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=node-taint-support"
+  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=private-gke-cluster-v1.1.0"
   gke_cluster_name       = var.infra_prefix
   project_name           = var.project_id
   gke_control_plane_zone = var.gke_control_plane_zone

--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -107,7 +107,7 @@ resource "google_storage_bucket_iam_member" "gene_cache" {
 
 # GKE Cluster
 module "gnomad-gke" {
-  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=private-gke-cluster-v1.0.4"
+  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=node-taint-support"
   gke_cluster_name       = var.infra_prefix
   project_name           = var.project_id
   gke_control_plane_zone = var.gke_control_plane_zone

--- a/gnomad-browser-infra/variables.tf
+++ b/gnomad-browser-infra/variables.tf
@@ -67,27 +67,26 @@ variable "gke_node_pools" {
   description = "A list of node pools and their configuration that should be created within the GKE cluster; pools with an empty string for the zone will deploy in the same region as the control plane"
   type = list(object({
     pool_name            = string
-    pool_num_nodes       = number
-    pool_machine_type    = string
-    pool_preemptible     = bool
-    pool_zone            = string
-    pool_resource_labels = map(string)
+    pool_num_nodes       = optional(number, 2)
+    pool_machine_type    = optional(string, "e2-medium")
+    pool_preemptible     = optional(bool, false)
+    pool_spot            = optional(bool, true)
+    pool_zone            = optional(string, "")
+    pool_resource_labels = optional(map(string), {})
+    pool_taints          = optional(list(object({ key = string, value = string, effect = string })), [])
   }))
   default = [
     {
-      "pool_name"            = "main-pool"
-      "pool_num_nodes"       = 2
-      "pool_machine_type"    = "e2-standard-4"
-      "pool_preemptible"     = false
-      "pool_zone"            = ""
-      "pool_resource_labels" = {}
+      "pool_name"         = "main-pool"
+      "pool_num_nodes"    = 2
+      "pool_machine_type" = "e2-standard-4"
+      "pool_spot"         = false
     },
     {
       "pool_name"         = "redis"
       "pool_num_nodes"    = 1
       "pool_machine_type" = "e2-custom-6-49152"
-      "pool_preemptible"  = false
-      "pool_zone"         = ""
+      "pool_spot"         = false
       "pool_resource_labels" = {
         "component" = "redis"
       }
@@ -96,8 +95,8 @@ variable "gke_node_pools" {
       "pool_name"         = "es-data"
       "pool_num_nodes"    = 3
       "pool_machine_type" = "e2-highmem-8"
-      "pool_preemptible"  = false
       "pool_zone"         = ""
+      "pool_spot"         = false
       "pool_resource_labels" = {
         "component" = "elasticsearch"
       }

--- a/gnomad-browser-infra/versions.tf
+++ b/gnomad-browser-infra/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -109,5 +109,14 @@ resource "google_container_node_pool" "node_pool" {
     tags = ["${var.gke_cluster_name}", "${var.gke_cluster_name}-${each.value.pool_name}"]
 
     resource_labels = each.value.pool_resource_labels
+
+    dynamic "taint" {
+      for_each = each.value.pool_taints
+      content {
+        effect = taint.value.effect
+        key    = taint.value.key
+        value  = taint.value.value
+      }
+    }
   }
 }

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -97,6 +97,7 @@ resource "google_container_node_pool" "node_pool" {
   node_config {
     machine_type    = each.value.pool_machine_type
     preemptible     = each.value.pool_preemptible
+    spot            = each.value.pool_spot
     service_account = google_service_account.gke_nodes.email
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform"

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -75,7 +75,7 @@ variable "node_pools" {
       "pool_preemptible"     = true
       "pool_zone"            = ""
       "pool_resource_labels" = {}
-      "pool_taints"          = {}
+      "pool_taints"          = []
     }
   ]
 }

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -65,7 +65,7 @@ variable "node_pools" {
     pool_preemptible     = bool
     pool_zone            = string
     pool_resource_labels = map(string)
-    pool_taints          = map(list(object({ key = string, value = string, effect = string })))
+    pool_taints          = list(object({ key = string, value = string, effect = string }))
   }))
   default = [
     {

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -65,6 +65,7 @@ variable "node_pools" {
     pool_preemptible     = bool
     pool_zone            = string
     pool_resource_labels = map(string)
+    pool_taints          = map(list(object({ key = string, value = string, effect = string })))
   }))
   default = [
     {
@@ -74,6 +75,7 @@ variable "node_pools" {
       "pool_preemptible"     = true
       "pool_zone"            = ""
       "pool_resource_labels" = {}
+      "pool_taints"          = {}
     }
   ]
 }

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -60,13 +60,13 @@ variable "node_pools" {
   description = "A list of node pools and their configuration that should be created within the GKE cluster; pools with an empty string for the zone will deploy in the same region as the control plane"
   type = list(object({
     pool_name            = string
-    pool_num_nodes       = number
-    pool_machine_type    = string
-    pool_preemptible     = bool
-    pool_spot            = bool
-    pool_zone            = string
-    pool_resource_labels = map(string)
-    pool_taints          = list(object({ key = string, value = string, effect = string }))
+    pool_num_nodes       = optional(number, 2)
+    pool_machine_type    = optional(string, "e2-medium")
+    pool_preemptible     = optional(bool, false)
+    pool_spot            = optional(bool, true)
+    pool_zone            = optional(string, "")
+    pool_resource_labels = optional(map(string), {})
+    pool_taints          = optional(list(object({ key = string, value = string, effect = string })), [])
   }))
   default = [
     {

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -63,6 +63,7 @@ variable "node_pools" {
     pool_num_nodes       = number
     pool_machine_type    = string
     pool_preemptible     = bool
+    pool_spot            = bool
     pool_zone            = string
     pool_resource_labels = map(string)
     pool_taints          = list(object({ key = string, value = string, effect = string }))
@@ -73,6 +74,7 @@ variable "node_pools" {
       "pool_num_nodes"       = 2
       "pool_machine_type"    = "e2-medium"
       "pool_preemptible"     = true
+      "pool_spot"            = false
       "pool_zone"            = ""
       "pool_resource_labels" = {}
       "pool_taints"          = []

--- a/private-gke-cluster/versions.tf
+++ b/private-gke-cluster/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
This adds support for node taints and spot nodes. Note we already had support for preemptibles, but Spot VMs are apparently different enough that google left hooks for both. This was to enable adding a new spot-node pool to the gnomad cluster, and adding a taint to it so that things didn't inadvertently schedule on it.

closes #28 

