### PR TITLE
add a gnomAD artifact registry module

### DIFF
--- a/gnomad-artifact-registry/README.md
+++ b/gnomad-artifact-registry/README.md
@@ -5,7 +5,42 @@ This module configures the standard set of artifact registry repositories for gn
 ## Usage
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
 
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.25.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.25.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_artifact_registry_repository.gnomad_repository](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cleanup_policy_dry_run"></a> [cleanup\_policy\_dry\_run](#input\_cleanup\_policy\_dry\_run) | Whether to run your cleanup policy in dry run mode | `bool` | `false` | no |
+| <a name="input_location"></a> [location](#input\_location) | The google cloud region to host your repositories in | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID you'd like to your repositories in | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_repository_id"></a> [repository\_id](#output\_repository\_id) | n/a |
 <!-- END_TF_DOCS -->
 
 ## Misc

--- a/gnomad-artifact-registry/README.md
+++ b/gnomad-artifact-registry/README.md
@@ -1,0 +1,19 @@
+# gnomAD artifact registry repos
+
+This module configures the standard set of artifact registry repositories for gnomAD and related browser development.
+
+## Usage
+
+<!-- BEGIN_TF_DOCS -->
+
+<!-- END_TF_DOCS -->
+
+## Misc
+
+### Updating this README
+
+The terraform documentation in this readme is generated with [terraform-docs](https://terraform-docs.io/). If you have modified the terraform code in a way that has added, removed, or changed a variable, resource, or output, you can regenerate the `TF_DOCS` block with:
+
+```bash
+terraform-docs markdown table --output-file README.md --output-mode inject .
+```

--- a/gnomad-artifact-registry/main.tf
+++ b/gnomad-artifact-registry/main.tf
@@ -7,14 +7,6 @@ resource "google_artifact_registry_repository" "gnomad_repository" {
   cleanup_policy_dry_run = var.cleanup_policy_dry_run
   # Cleanup Policy durations MUST be specified in seconds
   cleanup_policies {
-    id     = "delete-untagged"
-    action = "DELETE"
-    condition {
-      tag_state  = "UNTAGGED"
-      older_than = "5184000s" # 60 days
-    }
-  }
-  cleanup_policies {
     id     = "delete-demo"
     action = "DELETE"
     condition {
@@ -24,11 +16,11 @@ resource "google_artifact_registry_repository" "gnomad_repository" {
     }
   }
   cleanup_policies {
-    id     = "keep-tagged-prod-release"
-    action = "KEEP"
+    id     = "delete-older-than-1y"
+    action = "DELETE"
     condition {
-      tag_state    = "TAGGED"
-      tag_prefixes = ["prod"]
+      tag_state  = "ANY"
+      older_than = "31536000s" # 1 year
     }
   }
   cleanup_policies {

--- a/gnomad-artifact-registry/main.tf
+++ b/gnomad-artifact-registry/main.tf
@@ -7,15 +7,6 @@ resource "google_artifact_registry_repository" "gnomad_repository" {
   cleanup_policy_dry_run = var.cleanup_policy_dry_run
   # Cleanup Policy durations MUST be specified in seconds
   cleanup_policies {
-    id     = "delete-demo"
-    action = "DELETE"
-    condition {
-      tag_state    = "TAGGED"
-      tag_prefixes = ["demo"]
-      older_than   = "7776000s" # 90 days
-    }
-  }
-  cleanup_policies {
     id     = "delete-older-than-1y"
     action = "DELETE"
     condition {
@@ -28,7 +19,7 @@ resource "google_artifact_registry_repository" "gnomad_repository" {
     action = "KEEP"
     most_recent_versions {
       package_name_prefixes = ["gnomad", "exome-results", "legacy-redirects"]
-      keep_count            = 5
+      keep_count            = 25
     }
   }
 }

--- a/gnomad-artifact-registry/main.tf
+++ b/gnomad-artifact-registry/main.tf
@@ -1,0 +1,43 @@
+resource "google_artifact_registry_repository" "gnomad_repository" {
+  location               = var.location
+  project                = var.project_id
+  repository_id          = "gnomad"
+  description            = "docker repository for gnomAD images"
+  format                 = "DOCKER"
+  cleanup_policy_dry_run = var.cleanup_policy_dry_run
+  # Cleanup Policy durations MUST be specified in seconds
+  cleanup_policies {
+    id     = "delete-untagged"
+    action = "DELETE"
+    condition {
+      tag_state  = "UNTAGGED"
+      older_than = "5184000s" # 60 days
+    }
+  }
+  cleanup_policies {
+    id     = "delete-demo"
+    action = "DELETE"
+    condition {
+      tag_state    = "TAGGED"
+      tag_prefixes = ["demo"]
+      older_than   = "7776000s" # 90 days
+    }
+  }
+  cleanup_policies {
+    id     = "keep-tagged-prod-release"
+    action = "KEEP"
+    condition {
+      tag_state    = "TAGGED"
+      tag_prefixes = ["prod"]
+    }
+  }
+  cleanup_policies {
+    id     = "keep-minimum-versions"
+    action = "KEEP"
+    most_recent_versions {
+      package_name_prefixes = ["gnomad", "exome-results", "legacy-redirects"]
+      keep_count            = 5
+    }
+  }
+}
+

--- a/gnomad-artifact-registry/outputs.tf
+++ b/gnomad-artifact-registry/outputs.tf
@@ -1,0 +1,3 @@
+output "repository_id" {
+  value = google_artifact_registry_repository.gnomad_repository.id
+}

--- a/gnomad-artifact-registry/variables.tf
+++ b/gnomad-artifact-registry/variables.tf
@@ -1,0 +1,15 @@
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID you'd like to your repositories in"
+}
+
+variable "location" {
+  type        = string
+  description = "The google cloud region to host your repositories in"
+}
+
+variable "cleanup_policy_dry_run" {
+  type        = bool
+  description = "Whether to run your cleanup policy in dry run mode"
+  default     = false
+}

--- a/gnomad-artifact-registry/versions.tf
+++ b/gnomad-artifact-registry/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.7"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.25.0"
+    }
+  }
+}


### PR DESCRIPTION
This adds a wrapper so that we can deploy identically configured artifact registry repositories in our gnomAD browser projects.

This results in a single registry, where multiple docker image repositories can be stored, with a URL like `us-east1-docker.pkg.dev/gnomadev/gnomad/gnomad-browser:tag1` and `us-east1-docker.pkg.dev/gnomadev/gnomad/gnomad-api:tag1`

It also configures a few default image retention policies, with the intention being:
- delete anything prefixed with "demo" after 90 days
- delete untagged images after 60 days
- keep anything prefixed with "prod" indefinitely
- keep at least 5 versions of everything gnomad-ish, exome-results-browsers-ish, and legacy-redirects-ish