### PR TITLE
Update gke module for gnomad

### DIFF
--- a/gnomad-browser-infra/main.tf
+++ b/gnomad-browser-infra/main.tf
@@ -107,7 +107,7 @@ resource "google_storage_bucket_iam_member" "gene_cache" {
 
 # GKE Cluster
 module "gnomad-gke" {
-  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=private-gke-cluster-v1.1.0"
+  source                 = "github.com/broadinstitute/tgg-terraform-modules//private-gke-cluster?ref=private-gke-cluster-v1.1.1"
   gke_cluster_name       = var.infra_prefix
   project_name           = var.project_id
   gke_control_plane_zone = var.gke_control_plane_zone

--- a/gnomad-browser-infra/versions.tf
+++ b/gnomad-browser-infra/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.45.0"
+      version = ">= 5.44.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
This pulls in https://github.com/broadinstitute/tgg-terraform-modules/compare/a5a70793e5e95b07215020e8acdf9dfc8f69d5c9...8077a009a06f8a46009dde1e9a6b934fa4ded6c8

That update sets a default setting to ensure that this vulnerability https://cloud.google.com/kubernetes-engine/docs/how-to/disable-kubelet-readonly-port is not exploitable.