### PR TITLE
Support autoscaling nodepools

### DIFF
--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -98,14 +98,14 @@ resource "google_container_node_pool" "node_pool" {
   name     = each.value.pool_name
   location = each.value.pool_zone != "" ? each.value.pool_zone : var.gke_control_plane_zone
   cluster  = google_container_cluster.gke_cluster.name
-  // if we are using autoscale, null this parameter, else, use the defined value
-  node_count = (each.value.autoscale == null) ? each.value.pool_num_nodes : null
+  // if we are using autoscaling, null this parameter, else, use the defined value
+  node_count = (each.value.pool_autoscaling == null) ? each.value.pool_num_nodes : null
 
-  dynamic "autoscale" {
-    for_each = each.value.pool_autoscale
+  dynamic "autoscaling" {
+    for_each = each.value.pool_autoscaling[*]
     content {
-      min_node_count = autoscale.value.min_node_count
-      max_node_count = autoscale.value.max_node_count
+      min_node_count = autoscaling.value.min_pool_nodes
+      max_node_count = autoscaling.value.max_pool_nodes
     }
   }
 

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -67,7 +67,7 @@ variable "node_pools" {
     pool_zone            = optional(string, "")
     pool_resource_labels = optional(map(string), {})
     pool_taints          = optional(list(object({ key = string, value = string, effect = string })), [])
-    pool_autoscale       = optional(object({ min_pool_nodes = string, max_pool_nodes = string }))
+    pool_autoscaling     = optional(object({ min_pool_nodes = string, max_pool_nodes = string }))
   }))
   default = [
     {
@@ -79,7 +79,6 @@ variable "node_pools" {
       "pool_zone"            = ""
       "pool_resource_labels" = {}
       "pool_taints"          = []
-      "pool_autoscale"       = {}
     }
   ]
 }

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -67,6 +67,7 @@ variable "node_pools" {
     pool_zone            = optional(string, "")
     pool_resource_labels = optional(map(string), {})
     pool_taints          = optional(list(object({ key = string, value = string, effect = string })), [])
+    pool_autoscale       = optional(object({ min_pool_nodes = string, max_pool_nodes = string }))
   }))
   default = [
     {
@@ -78,6 +79,7 @@ variable "node_pools" {
       "pool_zone"            = ""
       "pool_resource_labels" = {}
       "pool_taints"          = []
+      "pool_autoscale"       = {}
     }
   ]
 }


### PR DESCRIPTION
This adds a config parameter to the node_pools variable in the private-gke-cluster module that allows for configuring node pools for autoscaling. Behavior patterns I tested here:

- existing cluster upgrading to this new version, no config changes: no incidental changes introduced (expected)
- Adding a new autoscaling node pool to an existing cluster: only the new pool was changes / added (expected)
- Changing an existing node pool from static -> autoscaling: seemed to work fine, maybe several minutes of jankyness on googles end while they figure out that the pool is now autoscaling, but eventually flattened out. Pool stays at the current # of nodes, and then starts evaluating scaledowns after 10 minutes.

I realize now writing this down that I didn't test changing from autoscaling -> to static... which I should probably do, but I wouldn't expect the code to change.