### PR TITLE
adds a boolean to optionally enable the GKE DNS endpoint

### DIFF
--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -70,7 +70,7 @@ resource "google_container_cluster" "gke_cluster" {
   private_cluster_config {
     enable_private_nodes    = true
     master_ipv4_cidr_block  = var.gke_master_ipv4_cidr_block
-    enable_private_endpoint = false
+    enable_private_endpoint = var.enable_private_only_ip_endpoint
   }
 
   release_channel {

--- a/private-gke-cluster/main.tf
+++ b/private-gke-cluster/main.tf
@@ -40,6 +40,12 @@ resource "google_container_cluster" "gke_cluster" {
     }
   }
 
+  control_plane_endpoints_config {
+    dns_endpoint_config {
+      allow_external_traffic = var.enable_dns_endpoint_config
+    }
+  }
+
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = var.gke_pods_range_slice
     services_ipv4_cidr_block = var.gke_services_range_slice

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -127,3 +127,9 @@ variable "enable_insecure_kubelet_port" {
     error_message = "The value provided must be a string matching either TRUE or FALSE"
   }
 }
+
+variable "enable_dns_endpoint_config" {
+  description = "Disables or Enables the DNS endpoint for the GKE control plane"
+  type        = bool
+  default     = false
+}

--- a/private-gke-cluster/variables.tf
+++ b/private-gke-cluster/variables.tf
@@ -133,3 +133,9 @@ variable "enable_dns_endpoint_config" {
   type        = bool
   default     = false
 }
+
+variable "enable_private_only_ip_endpoint" {
+  description = "Disables or Enabels the public IP address on your GKE control plane"
+  type        = bool
+  default     = false
+}

--- a/private-gke-cluster/versions.tf
+++ b/private-gke-cluster/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.0"
+      version = ">= 6.11.1"
     }
   }
 }


### PR DESCRIPTION
Due to [insanity](https://cloud.google.com/build/docs/private-pools/accessing-private-gke-clusters-with-cloud-build-private-pools) involved in trying to open up the GKE control plane to a set of private cloudbuild nodes, and not wanting to open our plane up to all of public google cloud build, I waited until DNS endpoints were available (as of google provider 6.11.1)

This change updates our module so that we can optionally enable that endpoint.

Note, that this technically makes the control plane accessible outside of your authorized nets, but my understanding (see: https://cloud.google.com/blog/products/containers-kubernetes/new-dns-based-endpoint-for-the-gke-control-plane) is that this configures an identity aware proxy in front of the control plane that requires IAM authentication from an account that you've granted the `container.clusters.connect` permission to in order to complete the connection.